### PR TITLE
Add support for 1.17

### DIFF
--- a/src/main/java/fr/mrmicky/fastboard/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoard.java
@@ -112,7 +112,9 @@ public class FastBoard {
             MESSAGE_FROM_STRING = lookup.unreflect(craftChatMessageClass.getMethod("fromString", String.class));
             CHAT_COMPONENT_CLASS = FastReflection.nmsClass("network.chat", "IChatBaseComponent");
             CHAT_FORMAT_ENUM = chatFormatEnum;
-            EMPTY_MESSAGE = FastReflection.nmsClass("network.chat", "ChatComponentText").getFields()[0].get(null);
+            EMPTY_MESSAGE = VersionType.V1_17.isHigherOrEqual() ?
+                    FastReflection.nmsClass("network.chat", "ChatComponentText").getFields()[0].get(null)
+                    : null;
             RESET_FORMATTING = FastReflection.enumValueOf(chatFormatEnum, "RESET", 21);
             PLAYER_GET_HANDLE = lookup.findVirtual(craftPlayerClass, "getHandle", MethodType.methodType(entityPlayerClass));
             PLAYER_CONNECTION = lookup.unreflectGetter(


### PR DESCRIPTION
Hello,
This PR adds support for the latest version of Spigot 1.17. Since class attributes are now obfuscated and classes in different packages, many changes have been made to the `FastReflection` class. Packets are now immutable, which prevents fields from being directly modified. I preferred to use `Unsafe` rather than changing the modifiers on the `Field`s, as it seems to me that it is not really possible anymore with Java 16.