### PR TITLE
Convert to legacy if paper isn't found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.12.0</version>
+            <version>4.13.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,12 @@
             <version>4.12.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-legacy</artifactId>
+            <version>4.13.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -55,13 +55,12 @@ public class FastBoard extends FastBoardBase<Component> {
             EMPTY_COMPONENT = AS_VANILLA.invoke(Component.empty());
             CONVERT_TO_LEGACY = false;
         } catch (Throwable t) {
-            AS_VANILLA = null;
-            CONVERT_TO_LEGACY = true;
             try {
                 MethodHandles.Lookup lookup = MethodHandles.lookup();
                 Class<?> craftChatMessageClass = FastReflection.obcClass("util.CraftChatMessage");
                 MESSAGE_FROM_STRING = lookup.unreflect(craftChatMessageClass.getMethod("fromString", String.class));
                 EMPTY_MESSAGE = Array.get(MESSAGE_FROM_STRING.invoke(""), 0);
+                CONVERT_TO_LEGACY = true;
             } catch (Throwable t2) {
                 throw new ExceptionInInitializerError(t);
             }

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -98,7 +98,7 @@ public class FastBoard extends FastBoardBase<Component> {
         }
 
         // Server supports adventure natively
-        return AS_VANILLA.invoke(component == null);
+        return AS_VANILLA.invoke(component);
     }
 
     @Override

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -89,7 +89,7 @@ public class FastBoard extends FastBoardBase<Component> {
     protected Object toMinecraftComponent(Component component) throws Throwable {
         // If the component is null, we return an empty component
         if(component == null) {
-            return EMPTY_MESSAGE;
+            return CONVERT_TO_LEGACY ? EMPTY_MESSAGE : EMPTY_COMPONENT;
         }
 
         // If the server isn't running adventure nativly, we convert the component to legacy text
@@ -99,7 +99,7 @@ public class FastBoard extends FastBoardBase<Component> {
         }
 
         // Server supports adventure natively
-        return AS_VANILLA.invoke(component);
+        return AS_VANILLA.invoke(component == null);
     }
 
     @Override


### PR DESCRIPTION
I added that if the paper adventure class isn't found, that should happen if the server is running spigot or is below 1.16, the components will be converted to strings and then to chat components.

The codes isn't tested yet.