### PR TITLE
Version 2.0 - Kyori Adventure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,11 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.20 
     </plugins>
 </build>
 
-<repositories>
-    <repository>
-        <id>sonatype-snapshots</id>
-        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
         <groupId>fr.mrmicky</groupId>
         <artifactId>fastboard</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </dependency>
 </dependencies>
 ```
@@ -75,15 +68,15 @@ When using Maven, be careful not to build directly with your IDE configuration b
 
 ```groovy
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 repositories {
-    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
+    mavenCentral()
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:2.0.0-SNAPSHOT'
+    implementation 'fr.mrmicky:fastboard:2.0.0'
 }
 
 shadowJar {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastBoard
+
 [![Java CI](https://github.com/MrMicky-FR/FastBoard/actions/workflows/build.yml/badge.svg)](https://github.com/MrMicky-FR/FastBoard/actions/workflows/build.yml)
-[![Language grade](https://img.shields.io/lgtm/grade/java/github/MrMicky-FR/FastBoard.svg?logo=lgtm&logoWidth=18&label=code%20quality)](https://lgtm.com/projects/g/MrMicky-FR/FastBoard/context:java)
 [![Maven Central](https://img.shields.io/maven-central/v/fr.mrmicky/fastboard.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22fr.mrmicky%22%20AND%20a:%22fastboard%22)
 [![Discord](https://img.shields.io/discord/390919659874156560.svg?colorB=5865f2&label=Discord&logo=discord&logoColor=white)](https://discord.gg/q9UwaBT)
 
@@ -20,6 +20,7 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.19 
 * Supports up to 30 characters per line on 1.12.2 and below
 * No character limit on 1.13 and higher
 * Supports hex colors on 1.16 and higher
+* [Adventure](https://github.com/KyoriPowered/adventure) components support
 
 ## Installation
 
@@ -56,7 +57,7 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.19 
     <dependency>
         <groupId>fr.mrmicky</groupId>
         <artifactId>fastboard</artifactId>
-        <version>1.2.1</version>
+        <version>2.0.0</version>
     </dependency>
 </dependencies>
 ```
@@ -73,7 +74,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:1.2.1'
+    implementation 'fr.mrmicky:fastboard:2.0.0'
 }
 
 shadowJar {
@@ -84,7 +85,7 @@ shadowJar {
 
 ### Manual
 
-Copy `FastBoard.java` and `FastReflection.java` in your plugin.
+Copy `FastBoardBase.java`, `FastBoard.java` and `FastReflection.java` in your plugin.
 
 ## Usage
 
@@ -114,7 +115,6 @@ Small example plugin with a scoreboard that refreshes every second:
 ```java
 package fr.mrmicky.fastboard.example;
 
-import fr.mrmicky.fastboard.FastBoard;
 import org.bukkit.ChatColor;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;
@@ -175,4 +175,24 @@ public final class ExamplePlugin extends JavaPlugin implements Listener {
         );
     }
 }
+```
+
+## Adventure support
+
+For servers on modern [PaperMC](https://papermc.io) versions, FastBoard supports
+using [Adventure](https://github.com/KyoriPowered/adventure) components instead of strings, 
+by using the class `fr.mrmicky.fastboard.adventure.FastBoard`.
+
+## ViaBackwards compatibility
+
+When using ViaBackwards on a post-1.13 server with pre-1.13 clients, older clients
+might get incomplete lines. To solve this issue, you can override the method `hasLinesMaxLength()` and return `true` for older clients.
+For example using the ViaVersion API:
+```java
+FastBoard board = new FastBoard(player) { 
+    @Override
+    public boolean hasLinesMaxLength() {
+        return Via.getAPI().getPlayerVersion(getPlayer()) < ProtocolVersion.v1_13.getVersion(); // or just 'return true;'
+    }
+});
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Small example plugin with a scoreboard that refreshes every second:
 ```java
 package fr.mrmicky.fastboard.example;
 
+import fr.mrmicky.fastboard.FastBoard;
 import org.bukkit.ChatColor;
 import org.bukkit.Statistic;
 import org.bukkit.entity.Player;

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ For servers on modern [PaperMC](https://papermc.io) versions, FastBoard supports
 using [Adventure](https://github.com/KyoriPowered/adventure) components instead of strings, 
 by using the class `fr.mrmicky.fastboard.adventure.FastBoard`.
 
+## RGB colors
+
+When using the non-Adventure version of FastBoard, RGB colors can be added on 1.16 and higher with `ChatColor.of("#RRGGBB")` (`net.md_5.bungee.api.ChatColor` import).
+
 ## ViaBackwards compatibility
 
 When using ViaBackwards on a post-1.13 server with pre-1.13 clients, older clients

--- a/README.md
+++ b/README.md
@@ -53,11 +53,18 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.19 
     </plugins>
 </build>
 
+<repositories>
+    <repository>
+        <id>sonatype-snapshots</id>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+</repositories>
+
 <dependencies>
     <dependency>
         <groupId>fr.mrmicky</groupId>
         <artifactId>fastboard</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```
@@ -72,11 +79,11 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:2.0.0'
+    implementation 'fr.mrmicky:fastboard:2.0.0-SNAPSHOT'
 }
 
 shadowJar {

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Maven Central](https://img.shields.io/maven-central/v/fr.mrmicky/fastboard.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22fr.mrmicky%22%20AND%20a:%22fastboard%22)
 [![Discord](https://img.shields.io/discord/390919659874156560.svg?colorB=5865f2&label=Discord&logo=discord&logoColor=white)](https://discord.gg/q9UwaBT)
 
-Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.19 support.
+Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.20 support.
 
 ⚠️ To use FastBoard on a 1.8 server, the server must be on 1.8.8.
 
 ## Features
 
 * No flickering (without using a buffer)
-* Works with all versions from 1.7.10 to 1.19
+* Works with all versions from 1.7.10 to 1.20
 * Very small (around 600 lines of code with the JavaDoc) and no dependencies
 * Easy to use
 * Dynamic scoreboard size: you don't need to add/remove lines, you can directly give a string list (or array) to change all the lines

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.19 
 </dependencies>
 ```
 
+When using Maven, be careful not to build directly with your IDE configuration but with Maven instead (on IntelliJ IDEA: in the `Maven` tab on the right, `Lifecycle` and `package`).
+
 ### Gradle
 
 ```groovy

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.20 
 </dependencies>
 ```
 
-When using Maven, be careful not to build directly with your IDE configuration but with Maven instead (on IntelliJ IDEA: in the `Maven` tab on the right, `Lifecycle` and `package`).
+When using Maven, make sure to build directly with Maven and not with your IDE configuration. (on IntelliJ IDEA: in the `Maven` tab on the right, in `Lifecycle`, use `package`).
 
 ### Gradle
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.mrmicky</groupId>
     <artifactId>fastboard</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>FastBoard</name>
     <description>Lightweight packet-based scoreboard API for Bukkit plugins.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,13 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.12.0</version>
+            <version>4.13.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-serializer-legacy</artifactId>
+            <version>4.13.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.mrmicky</groupId>
     <artifactId>fastboard</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <name>FastBoard</name>
     <description>Lightweight packet-based scoreboard API for Bukkit plugins.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.mrmicky</groupId>
     <artifactId>fastboard</artifactId>
-    <version>1.2.1</version>
+    <version>2.0.0</version>
 
     <name>FastBoard</name>
     <description>Lightweight packet-based scoreboard API for Bukkit plugins.</description>
@@ -53,6 +53,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.12.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/fr/mrmicky/fastboard/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoard.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FastBoard, licensed under the MIT License.
  *
- * Copyright (c) 2019-2021 MrMicky
+ * Copyright (c) 2019-2023 MrMicky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/fr/mrmicky/fastboard/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoard.java
@@ -28,294 +28,55 @@ import org.bukkit.entity.Player;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Lightweight packet-based scoreboard API for Bukkit plugins.
- * It can be safely used asynchronously as everything is at packet level.
- * <p>
- * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
- *
- * @author MrMicky
- * @version 1.2.1
+ * {@inheritDoc}
  */
-public class FastBoard {
+public class FastBoard extends FastBoardBase<String> {
 
-    private static final Map<Class<?>, Field[]> PACKETS = new HashMap<>(8);
-    private static final String[] COLOR_CODES = Arrays.stream(ChatColor.values())
-            .map(Object::toString)
-            .toArray(String[]::new);
-    private static final VersionType VERSION_TYPE;
-    // Packets and components
-    private static final Class<?> CHAT_COMPONENT_CLASS;
-    private static final Class<?> CHAT_FORMAT_ENUM;
-    private static final Object EMPTY_MESSAGE;
-    private static final Object RESET_FORMATTING;
     private static final MethodHandle MESSAGE_FROM_STRING;
-    private static final MethodHandle PLAYER_CONNECTION;
-    private static final MethodHandle SEND_PACKET;
-    private static final MethodHandle PLAYER_GET_HANDLE;
-    // Scoreboard packets
-    private static final FastReflection.PacketConstructor PACKET_SB_OBJ;
-    private static final FastReflection.PacketConstructor PACKET_SB_DISPLAY_OBJ;
-    private static final FastReflection.PacketConstructor PACKET_SB_SCORE;
-    private static final FastReflection.PacketConstructor PACKET_SB_TEAM;
-    private static final FastReflection.PacketConstructor PACKET_SB_SERIALIZABLE_TEAM;
-    // Scoreboard enums
-    private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
-    private static final Class<?> ENUM_SB_ACTION;
-    private static final Object ENUM_SB_HEALTH_DISPLAY_INTEGER;
-    private static final Object ENUM_SB_ACTION_CHANGE;
-    private static final Object ENUM_SB_ACTION_REMOVE;
+    private static final Object EMPTY_MESSAGE;
 
     static {
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
-
-            if (FastReflection.isRepackaged()) {
-                VERSION_TYPE = VersionType.V1_17;
-            } else if (FastReflection.nmsOptionalClass(null, "ScoreboardServer$Action").isPresent()) {
-                VERSION_TYPE = VersionType.V1_13;
-            } else if (FastReflection.nmsOptionalClass(null, "IScoreboardCriteria$EnumScoreboardHealthDisplay").isPresent()) {
-                VERSION_TYPE = VersionType.V1_8;
-            } else {
-                VERSION_TYPE = VersionType.V1_7;
-            }
-
-            String gameProtocolPackage = "network.protocol.game";
-            Class<?> craftPlayerClass = FastReflection.obcClass("entity.CraftPlayer");
             Class<?> craftChatMessageClass = FastReflection.obcClass("util.CraftChatMessage");
-            Class<?> entityPlayerClass = FastReflection.nmsClass("server.level", "EntityPlayer");
-            Class<?> playerConnectionClass = FastReflection.nmsClass("server.network", "PlayerConnection");
-            Class<?> packetClass = FastReflection.nmsClass("network.protocol", "Packet");
-            Class<?> packetSbObjClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardObjective");
-            Class<?> packetSbDisplayObjClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardDisplayObjective");
-            Class<?> packetSbScoreClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardScore");
-            Class<?> packetSbTeamClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardTeam");
-            Class<?> sbTeamClass = VersionType.V1_17.isHigherOrEqual()
-                    ? FastReflection.innerClass(packetSbTeamClass, innerClass -> !innerClass.isEnum()) : null;
-            Field playerConnectionField = Arrays.stream(entityPlayerClass.getFields())
-                    .filter(field -> field.getType().isAssignableFrom(playerConnectionClass))
-                    .findFirst().orElseThrow(NoSuchFieldException::new);
-            Method sendPacketMethod = Arrays.stream(playerConnectionClass.getMethods())
-                    .filter(m -> m.getParameterCount() == 1 && m.getParameterTypes()[0] == packetClass)
-                    .findFirst().orElseThrow(NoSuchMethodException::new);
-
             MESSAGE_FROM_STRING = lookup.unreflect(craftChatMessageClass.getMethod("fromString", String.class));
-            CHAT_COMPONENT_CLASS = FastReflection.nmsClass("network.chat", "IChatBaseComponent");
-            CHAT_FORMAT_ENUM = FastReflection.nmsClass(null, "EnumChatFormat");
             EMPTY_MESSAGE = Array.get(MESSAGE_FROM_STRING.invoke(""), 0);
-            RESET_FORMATTING = FastReflection.enumValueOf(CHAT_FORMAT_ENUM, "RESET", 21);
-            PLAYER_GET_HANDLE = lookup.findVirtual(craftPlayerClass, "getHandle", MethodType.methodType(entityPlayerClass));
-            PLAYER_CONNECTION = lookup.unreflectGetter(playerConnectionField);
-            SEND_PACKET = lookup.unreflect(sendPacketMethod);
-            PACKET_SB_OBJ = FastReflection.findPacketConstructor(packetSbObjClass, lookup);
-            PACKET_SB_DISPLAY_OBJ = FastReflection.findPacketConstructor(packetSbDisplayObjClass, lookup);
-            PACKET_SB_SCORE = FastReflection.findPacketConstructor(packetSbScoreClass, lookup);
-            PACKET_SB_TEAM = FastReflection.findPacketConstructor(packetSbTeamClass, lookup);
-            PACKET_SB_SERIALIZABLE_TEAM = sbTeamClass == null ? null : FastReflection.findPacketConstructor(sbTeamClass, lookup);
-
-            for (Class<?> clazz : Arrays.asList(packetSbObjClass, packetSbDisplayObjClass, packetSbScoreClass, packetSbTeamClass, sbTeamClass)) {
-                if (clazz == null) {
-                    continue;
-                }
-                Field[] fields = Arrays.stream(clazz.getDeclaredFields())
-                        .filter(field -> !Modifier.isStatic(field.getModifiers()))
-                        .toArray(Field[]::new);
-                for (Field field : fields) {
-                    field.setAccessible(true);
-                }
-                PACKETS.put(clazz, fields);
-            }
-
-            if (VersionType.V1_8.isHigherOrEqual()) {
-                String enumSbActionClass = VersionType.V1_13.isHigherOrEqual()
-                        ? "ScoreboardServer$Action"
-                        : "PacketPlayOutScoreboardScore$EnumScoreboardAction";
-                ENUM_SB_HEALTH_DISPLAY = FastReflection.nmsClass("world.scores.criteria", "IScoreboardCriteria$EnumScoreboardHealthDisplay");
-                ENUM_SB_ACTION = FastReflection.nmsClass("server", enumSbActionClass);
-                ENUM_SB_HEALTH_DISPLAY_INTEGER = FastReflection.enumValueOf(ENUM_SB_HEALTH_DISPLAY, "INTEGER", 0);
-                ENUM_SB_ACTION_CHANGE = FastReflection.enumValueOf(ENUM_SB_ACTION, "CHANGE", 0);
-                ENUM_SB_ACTION_REMOVE = FastReflection.enumValueOf(ENUM_SB_ACTION, "REMOVE", 1);
-            } else {
-                ENUM_SB_HEALTH_DISPLAY = null;
-                ENUM_SB_ACTION = null;
-                ENUM_SB_HEALTH_DISPLAY_INTEGER = null;
-                ENUM_SB_ACTION_CHANGE = null;
-                ENUM_SB_ACTION_REMOVE = null;
-            }
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
     }
 
-    private final Player player;
-    private final String id;
-
-    private final List<String> lines = new ArrayList<>();
-    private String title = ChatColor.RESET.toString();
-
-    private boolean deleted = false;
-
     /**
-     * Creates a new FastBoard.
-     *
-     * @param player the owner of the scoreboard
+     * {@inheritDoc}
      */
     public FastBoard(Player player) {
-        this.player = Objects.requireNonNull(player, "player");
-        this.id = "fb-" + Integer.toHexString(ThreadLocalRandom.current().nextInt());
-
-        try {
-            sendObjectivePacket(ObjectiveMode.CREATE);
-            sendDisplayObjectivePacket();
-        } catch (Throwable t) {
-            throw new RuntimeException("Unable to create scoreboard", t);
-        }
+        super(player);
     }
 
     /**
-     * Get the scoreboard title.
-     *
-     * @return the scoreboard title
+     * {@inheritDoc}
      */
-    public String getTitle() {
-        return this.title;
-    }
-
-    /**
-     * Update the scoreboard title.
-     *
-     * @param title the new scoreboard title
-     * @throws IllegalArgumentException if the title is longer than 32 chars on 1.12 or lower
-     * @throws IllegalStateException    if {@link #delete()} was call before
-     */
+    @Override
     public void updateTitle(String title) {
-        if (this.title.equals(Objects.requireNonNull(title, "title"))) {
-            return;
-        }
+        Objects.requireNonNull(title, "title");
 
         if (!VersionType.V1_13.isHigherOrEqual() && title.length() > 32) {
             throw new IllegalArgumentException("Title is longer than 32 chars");
         }
 
-        this.title = title;
-
-        try {
-            sendObjectivePacket(ObjectiveMode.UPDATE);
-        } catch (Throwable t) {
-            throw new RuntimeException("Unable to update scoreboard title", t);
-        }
+        super.updateTitle(title);
     }
 
     /**
-     * Get the scoreboard lines.
-     *
-     * @return the scoreboard lines
+     * {@inheritDoc}
      */
-    public List<String> getLines() {
-        return new ArrayList<>(this.lines);
-    }
-
-    /**
-     * Get the specified scoreboard line.
-     *
-     * @param line the line number
-     * @return the line
-     * @throws IndexOutOfBoundsException if the line is higher than {@code size}
-     */
-    public String getLine(int line) {
-        checkLineNumber(line, true, false);
-
-        return this.lines.get(line);
-    }
-
-    /**
-     * Update a single scoreboard line.
-     *
-     * @param line the line number
-     * @param text the new line text
-     * @throws IndexOutOfBoundsException if the line is higher than {@link #size() size() + 1}
-     */
-    public synchronized void updateLine(int line, String text) {
-        checkLineNumber(line, false, true);
-
-        try {
-            if (line < size()) {
-                this.lines.set(line, text);
-
-                sendTeamPacket(getScoreByLine(line), TeamMode.UPDATE);
-                return;
-            }
-
-            List<String> newLines = new ArrayList<>(this.lines);
-
-            if (line > size()) {
-                for (int i = size(); i < line; i++) {
-                    newLines.add("");
-                }
-            }
-
-            newLines.add(text);
-
-            updateLines(newLines);
-        } catch (Throwable t) {
-            throw new RuntimeException("Unable to update scoreboard lines", t);
-        }
-    }
-
-    /**
-     * Remove a scoreboard line.
-     *
-     * @param line the line number
-     */
-    public synchronized void removeLine(int line) {
-        checkLineNumber(line, false, false);
-
-        if (line >= size()) {
-            return;
-        }
-
-        List<String> newLines = new ArrayList<>(this.lines);
-        newLines.remove(line);
-        updateLines(newLines);
-    }
-
-    /**
-     * Update all the scoreboard lines.
-     *
-     * @param lines the new lines
-     * @throws IllegalArgumentException if one line is longer than 30 chars on 1.12 or lower
-     * @throws IllegalStateException    if {@link #delete()} was call before
-     */
+    @Override
     public void updateLines(String... lines) {
-        updateLines(Arrays.asList(lines));
-    }
-
-    /**
-     * Update the lines of the scoreboard
-     *
-     * @param lines the new scoreboard lines
-     * @throws IllegalArgumentException if one line is longer than 30 chars on 1.12 or lower
-     * @throws IllegalStateException    if {@link #delete()} was call before
-     */
-    public synchronized void updateLines(Collection<String> lines) {
         Objects.requireNonNull(lines, "lines");
-        checkLineNumber(lines.size(), false, true);
 
         if (!VersionType.V1_13.isHigherOrEqual()) {
             int lineCount = 0;
@@ -327,97 +88,59 @@ public class FastBoard {
             }
         }
 
-        List<String> oldLines = new ArrayList<>(this.lines);
-        this.lines.clear();
-        this.lines.addAll(lines);
+        super.updateLines(lines);
+    }
 
-        int linesSize = this.lines.size();
+    @Override
+    protected void sendLineChange(int score) throws Throwable {
+        int maxLength = hasLinesMaxLength() ? 16 : 1024;
+        String line = getLineByScore(score);
+        String prefix;
+        String suffix = "";
 
-        try {
-            if (oldLines.size() != linesSize) {
-                List<String> oldLinesCopy = new ArrayList<>(oldLines);
+        if (line == null || line.isEmpty()) {
+            prefix = COLOR_CODES[score] + ChatColor.RESET;
+        } else if (line.length() <= maxLength) {
+            prefix = line;
+        } else {
+            // Prevent splitting color codes
+            int index = line.charAt(maxLength - 1) == ChatColor.COLOR_CHAR
+                    ? (maxLength - 1) : maxLength;
+            prefix = line.substring(0, index);
+            String suffixTmp = line.substring(index);
+            ChatColor chatColor = null;
 
-                if (oldLines.size() > linesSize) {
-                    for (int i = oldLinesCopy.size(); i > linesSize; i--) {
-                        sendTeamPacket(i - 1, TeamMode.REMOVE);
-                        sendScorePacket(i - 1, ScoreboardAction.REMOVE);
-
-                        oldLines.remove(0);
-                    }
-                } else {
-                    for (int i = oldLinesCopy.size(); i < linesSize; i++) {
-                        sendScorePacket(i, ScoreboardAction.CHANGE);
-                        sendTeamPacket(i, TeamMode.CREATE);
-
-                        oldLines.add(oldLines.size() - i, getLineByScore(i));
-                    }
-                }
+            if (suffixTmp.length() >= 2 && suffixTmp.charAt(0) == ChatColor.COLOR_CHAR) {
+                chatColor = ChatColor.getByChar(suffixTmp.charAt(1));
             }
 
-            for (int i = 0; i < linesSize; i++) {
-                if (!Objects.equals(getLineByScore(oldLines, i), getLineByScore(i))) {
-                    sendTeamPacket(i, TeamMode.UPDATE);
-                }
-            }
-        } catch (Throwable t) {
-            throw new RuntimeException("Unable to update scoreboard lines", t);
-        }
-    }
+            String color = ChatColor.getLastColors(prefix);
+            boolean addColor = chatColor == null || chatColor.isFormat();
 
-    /**
-     * Get the player who has the scoreboard.
-     *
-     * @return current player for this FastBoard
-     */
-    public Player getPlayer() {
-        return this.player;
-    }
-
-    /**
-     * Get the scoreboard id.
-     *
-     * @return the id
-     */
-    public String getId() {
-        return this.id;
-    }
-
-    /**
-     * Get if the scoreboard is deleted.
-     *
-     * @return true if the scoreboard is deleted
-     */
-    public boolean isDeleted() {
-        return this.deleted;
-    }
-
-    /**
-     * Get the scoreboard size (the number of lines).
-     *
-     * @return the size
-     */
-    public int size() {
-        return this.lines.size();
-    }
-
-    /**
-     * Delete this FastBoard, and will remove the scoreboard for the associated player if he is online.
-     * After this, all uses of {@link #updateLines} and {@link #updateTitle} will throws an {@link IllegalStateException}
-     *
-     * @throws IllegalStateException if this was already call before
-     */
-    public void delete() {
-        try {
-            for (int i = 0; i < this.lines.size(); i++) {
-                sendTeamPacket(i, TeamMode.REMOVE);
-            }
-
-            sendObjectivePacket(ObjectiveMode.REMOVE);
-        } catch (Throwable t) {
-            throw new RuntimeException("Unable to delete scoreboard", t);
+            suffix = (addColor ? (color.isEmpty() ? ChatColor.RESET.toString() : color) : "") + suffixTmp;
         }
 
-        this.deleted = true;
+        if (prefix.length() > maxLength || suffix.length() > maxLength) {
+            // Something went wrong, just cut to prevent client crash/kick
+            prefix = prefix.substring(0, maxLength);
+            suffix = suffix.substring(0, maxLength);
+        }
+
+        sendTeamPacket(score, TeamMode.UPDATE, prefix, suffix);
+    }
+
+    @Override
+    protected Object toMinecraftComponent(String line) throws Throwable {
+        if (line == null || line.isEmpty()) {
+            return EMPTY_MESSAGE;
+        }
+
+        return Array.get(MESSAGE_FROM_STRING.invoke(line), 0);
+    }
+
+    @Override
+    protected String emptyLine() {
+        return "";
     }
 
     /**
@@ -429,205 +152,5 @@ public class FastBoard {
      */
     protected boolean hasLinesMaxLength() {
         return !VersionType.V1_13.isHigherOrEqual();
-    }
-
-    private void checkLineNumber(int line, boolean checkInRange, boolean checkMax) {
-        if (line < 0) {
-            throw new IllegalArgumentException("Line number must be positive");
-        }
-
-        if (checkInRange && line >= this.lines.size()) {
-            throw new IllegalArgumentException("Line number must be under " + this.lines.size());
-        }
-
-        if (checkMax && line >= COLOR_CODES.length - 1) {
-            throw new IllegalArgumentException("Line number is too high: " + line);
-        }
-    }
-
-    private int getScoreByLine(int line) {
-        return this.lines.size() - line - 1;
-    }
-
-    private String getLineByScore(int score) {
-        return getLineByScore(this.lines, score);
-    }
-
-    private String getLineByScore(List<String> lines, int score) {
-        return lines.get(lines.size() - score - 1);
-    }
-
-    private void sendObjectivePacket(ObjectiveMode mode) throws Throwable {
-        Object packet = PACKET_SB_OBJ.invoke();
-
-        setField(packet, String.class, this.id);
-        setField(packet, int.class, mode.ordinal());
-
-        if (mode != ObjectiveMode.REMOVE) {
-            setComponentField(packet, this.title, 1);
-
-            if (VersionType.V1_8.isHigherOrEqual()) {
-                setField(packet, ENUM_SB_HEALTH_DISPLAY, ENUM_SB_HEALTH_DISPLAY_INTEGER);
-            }
-        } else if (VERSION_TYPE == VersionType.V1_7) {
-            setField(packet, String.class, "", 1);
-        }
-
-        sendPacket(packet);
-    }
-
-    private void sendDisplayObjectivePacket() throws Throwable {
-        Object packet = PACKET_SB_DISPLAY_OBJ.invoke();
-
-        setField(packet, int.class, 1); // Position (1: sidebar)
-        setField(packet, String.class, this.id); // Score Name
-
-        sendPacket(packet);
-    }
-
-    private void sendScorePacket(int score, ScoreboardAction action) throws Throwable {
-        Object packet = PACKET_SB_SCORE.invoke();
-
-        setField(packet, String.class, COLOR_CODES[score], 0); // Player Name
-
-        if (VersionType.V1_8.isHigherOrEqual()) {
-            setField(packet, ENUM_SB_ACTION, action == ScoreboardAction.REMOVE ? ENUM_SB_ACTION_REMOVE : ENUM_SB_ACTION_CHANGE);
-        } else {
-            setField(packet, int.class, action.ordinal(), 1); // Action
-        }
-
-        if (action == ScoreboardAction.CHANGE) {
-            setField(packet, String.class, this.id, 1); // Objective Name
-            setField(packet, int.class, score); // Score
-        }
-
-        sendPacket(packet);
-    }
-
-    private void sendTeamPacket(int score, TeamMode mode) throws Throwable {
-        if (mode == TeamMode.ADD_PLAYERS || mode == TeamMode.REMOVE_PLAYERS) {
-            throw new UnsupportedOperationException();
-        }
-
-        int maxLength = hasLinesMaxLength() ? 16 : 1024;
-        Object packet = PACKET_SB_TEAM.invoke();
-
-        setField(packet, String.class, this.id + ':' + score); // Team name
-        setField(packet, int.class, mode.ordinal(), VERSION_TYPE == VersionType.V1_8 ? 1 : 0); // Update mode
-
-        if (mode == TeamMode.CREATE || mode == TeamMode.UPDATE) {
-            String line = getLineByScore(score);
-            String prefix;
-            String suffix = null;
-
-            if (line == null || line.isEmpty()) {
-                prefix = COLOR_CODES[score] + ChatColor.RESET;
-            } else if (line.length() <= maxLength) {
-                prefix = line;
-            } else {
-                // Prevent splitting color codes
-                int index = line.charAt(maxLength - 1) == ChatColor.COLOR_CHAR ? (maxLength - 1) : maxLength;
-                prefix = line.substring(0, index);
-                String suffixTmp = line.substring(index);
-                ChatColor chatColor = null;
-
-                if (suffixTmp.length() >= 2 && suffixTmp.charAt(0) == ChatColor.COLOR_CHAR) {
-                    chatColor = ChatColor.getByChar(suffixTmp.charAt(1));
-                }
-
-                String color = ChatColor.getLastColors(prefix);
-                boolean addColor = chatColor == null || chatColor.isFormat();
-
-                suffix = (addColor ? (color.isEmpty() ? ChatColor.RESET.toString() : color) : "") + suffixTmp;
-            }
-
-            if (prefix.length() > maxLength || (suffix != null && suffix.length() > maxLength)) {
-                // Something went wrong, just cut to prevent client crash/kick
-                prefix = prefix.substring(0, maxLength);
-                suffix = (suffix != null) ? suffix.substring(0, maxLength) : null;
-            }
-
-            if (VersionType.V1_17.isHigherOrEqual()) {
-                Object team = PACKET_SB_SERIALIZABLE_TEAM.invoke();
-                // Since the packet is initialized with null values, we need to change more things.
-                setComponentField(team, "", 0); // Display name
-                setField(team, CHAT_FORMAT_ENUM, RESET_FORMATTING); // Color
-                setComponentField(team, prefix, 1); // Prefix
-                setComponentField(team, suffix == null ? "" : suffix, 2); // Suffix
-                setField(team, String.class, "always", 0); // Visibility
-                setField(team, String.class, "always", 1); // Collisions
-                setField(packet, Optional.class, Optional.of(team));
-            } else {
-                setComponentField(packet, prefix, 2); // Prefix
-                setComponentField(packet, suffix == null ? "" : suffix, 3); // Suffix
-                setField(packet, String.class, "always", 4); // Visibility for 1.8+
-                setField(packet, String.class, "always", 5); // Collisions for 1.9+
-            }
-
-            if (mode == TeamMode.CREATE) {
-                setField(packet, Collection.class, Collections.singletonList(COLOR_CODES[score])); // Players in the team
-            }
-        }
-
-        sendPacket(packet);
-    }
-
-    private void sendPacket(Object packet) throws Throwable {
-        if (this.deleted) {
-            throw new IllegalStateException("This FastBoard is deleted");
-        }
-
-        if (this.player.isOnline()) {
-            Object entityPlayer = PLAYER_GET_HANDLE.invoke(this.player);
-            Object playerConnection = PLAYER_CONNECTION.invoke(entityPlayer);
-            SEND_PACKET.invoke(playerConnection, packet);
-        }
-    }
-
-    private void setField(Object object, Class<?> fieldType, Object value) throws ReflectiveOperationException {
-        setField(object, fieldType, value, 0);
-    }
-
-    private void setField(Object packet, Class<?> fieldType, Object value, int count) throws ReflectiveOperationException {
-        int i = 0;
-        for (Field field : PACKETS.get(packet.getClass())) {
-            if (field.getType() == fieldType && count == i++) {
-                field.set(packet, value);
-            }
-        }
-    }
-
-    private void setComponentField(Object packet, String value, int count) throws Throwable {
-        if (!VersionType.V1_13.isHigherOrEqual()) {
-            setField(packet, String.class, value, count);
-            return;
-        }
-
-        int i = 0;
-        for (Field field : PACKETS.get(packet.getClass())) {
-            if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
-                field.set(packet, value.isEmpty() ? EMPTY_MESSAGE : Array.get(MESSAGE_FROM_STRING.invoke(value), 0));
-            }
-        }
-    }
-
-    enum ObjectiveMode {
-        CREATE, REMOVE, UPDATE
-    }
-
-    enum TeamMode {
-        CREATE, REMOVE, UPDATE, ADD_PLAYERS, REMOVE_PLAYERS
-    }
-
-    enum ScoreboardAction {
-        CHANGE, REMOVE
-    }
-
-    enum VersionType {
-        V1_7, V1_8, V1_13, V1_17;
-
-        public boolean isHigherOrEqual() {
-            return VERSION_TYPE.ordinal() >= ordinal();
-        }
     }
 }

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
  *
  * @author MrMicky
- * @version 2.0.0
+ * @version 2.0.0-SNAPSHOT
  */
 public abstract class FastBoardBase<T> {
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -248,7 +248,7 @@ public abstract class FastBoardBase<T> {
             if (line < size()) {
                 this.lines.set(line, text);
 
-                sendTeamPacket(getScoreByLine(line), TeamMode.UPDATE);
+                sendLineChange(getScoreByLine(line));
                 return;
             }
 
@@ -328,8 +328,6 @@ public abstract class FastBoardBase<T> {
                     for (int i = oldLinesCopy.size(); i < linesSize; i++) {
                         sendScorePacket(i, ScoreboardAction.CHANGE);
                         sendTeamPacket(i, TeamMode.CREATE, null, null);
-
-                        oldLines.add(oldLines.size() - i, getLineByScore(i));
                     }
                 }
             }
@@ -429,7 +427,7 @@ public abstract class FastBoardBase<T> {
     }
 
     protected T getLineByScore(List<T> lines, int score) {
-        return lines.get(lines.size() - score - 1);
+        return score < lines.size() ? lines.get(lines.size() - score - 1) : null;
     }
 
     protected void sendObjectivePacket(ObjectiveMode mode) throws Throwable {
@@ -554,7 +552,7 @@ public abstract class FastBoardBase<T> {
 
     private void setComponentField(Object packet, T value, int count) throws Throwable {
         if (!VersionType.V1_13.isHigherOrEqual()) {
-            setField(packet, String.class, value, count);
+            setField(packet, String.class, value != null ? value : "", count);
             return;
         }
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -1,0 +1,588 @@
+/*
+ * This file is part of FastBoard, licensed under the MIT License.
+ *
+ * Copyright (c) 2019-2021 MrMicky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package fr.mrmicky.fastboard;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Lightweight packet-based scoreboard API for Bukkit plugins.
+ * It can be safely used asynchronously as everything is at packet level.
+ * <p>
+ * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
+ *
+ * @author MrMicky
+ * @version 2.0.0
+ */
+public abstract class FastBoardBase<T> {
+
+    private static final Map<Class<?>, Field[]> PACKETS = new HashMap<>(8);
+    protected static final String[] COLOR_CODES = Arrays.stream(ChatColor.values())
+            .map(Object::toString)
+            .toArray(String[]::new);
+    private static final VersionType VERSION_TYPE;
+    // Packets and components
+    private static final Class<?> CHAT_COMPONENT_CLASS;
+    private static final Class<?> CHAT_FORMAT_ENUM;
+    private static final Object RESET_FORMATTING;
+    private static final MethodHandle PLAYER_CONNECTION;
+    private static final MethodHandle SEND_PACKET;
+    private static final MethodHandle PLAYER_GET_HANDLE;
+    // Scoreboard packets
+    private static final FastReflection.PacketConstructor PACKET_SB_OBJ;
+    private static final FastReflection.PacketConstructor PACKET_SB_DISPLAY_OBJ;
+    private static final FastReflection.PacketConstructor PACKET_SB_SCORE;
+    private static final FastReflection.PacketConstructor PACKET_SB_TEAM;
+    private static final FastReflection.PacketConstructor PACKET_SB_SERIALIZABLE_TEAM;
+    // Scoreboard enums
+    private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
+    private static final Class<?> ENUM_SB_ACTION;
+    private static final Object ENUM_SB_HEALTH_DISPLAY_INTEGER;
+    private static final Object ENUM_SB_ACTION_CHANGE;
+    private static final Object ENUM_SB_ACTION_REMOVE;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+
+            if (FastReflection.isRepackaged()) {
+                VERSION_TYPE = VersionType.V1_17;
+            } else if (FastReflection.nmsOptionalClass(null, "ScoreboardServer$Action").isPresent()) {
+                VERSION_TYPE = VersionType.V1_13;
+            } else if (FastReflection.nmsOptionalClass(null, "IScoreboardCriteria$EnumScoreboardHealthDisplay").isPresent()) {
+                VERSION_TYPE = VersionType.V1_8;
+            } else {
+                VERSION_TYPE = VersionType.V1_7;
+            }
+
+            String gameProtocolPackage = "network.protocol.game";
+            Class<?> craftPlayerClass = FastReflection.obcClass("entity.CraftPlayer");
+            Class<?> entityPlayerClass = FastReflection.nmsClass("server.level", "EntityPlayer");
+            Class<?> playerConnectionClass = FastReflection.nmsClass("server.network", "PlayerConnection");
+            Class<?> packetClass = FastReflection.nmsClass("network.protocol", "Packet");
+            Class<?> packetSbObjClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardObjective");
+            Class<?> packetSbDisplayObjClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardDisplayObjective");
+            Class<?> packetSbScoreClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardScore");
+            Class<?> packetSbTeamClass = FastReflection.nmsClass(gameProtocolPackage, "PacketPlayOutScoreboardTeam");
+            Class<?> sbTeamClass = VersionType.V1_17.isHigherOrEqual()
+                    ? FastReflection.innerClass(packetSbTeamClass, innerClass -> !innerClass.isEnum()) : null;
+            Field playerConnectionField = Arrays.stream(entityPlayerClass.getFields())
+                    .filter(field -> field.getType().isAssignableFrom(playerConnectionClass))
+                    .findFirst().orElseThrow(NoSuchFieldException::new);
+            Method sendPacketMethod = Arrays.stream(playerConnectionClass.getMethods())
+                    .filter(m -> m.getParameterCount() == 1 && m.getParameterTypes()[0] == packetClass)
+                    .findFirst().orElseThrow(NoSuchMethodException::new);
+
+            CHAT_COMPONENT_CLASS = FastReflection.nmsClass("network.chat", "IChatBaseComponent");
+            CHAT_FORMAT_ENUM = FastReflection.nmsClass(null, "EnumChatFormat");
+            RESET_FORMATTING = FastReflection.enumValueOf(CHAT_FORMAT_ENUM, "RESET", 21);
+            PLAYER_GET_HANDLE = lookup.findVirtual(craftPlayerClass, "getHandle", MethodType.methodType(entityPlayerClass));
+            PLAYER_CONNECTION = lookup.unreflectGetter(playerConnectionField);
+            SEND_PACKET = lookup.unreflect(sendPacketMethod);
+            PACKET_SB_OBJ = FastReflection.findPacketConstructor(packetSbObjClass, lookup);
+            PACKET_SB_DISPLAY_OBJ = FastReflection.findPacketConstructor(packetSbDisplayObjClass, lookup);
+            PACKET_SB_SCORE = FastReflection.findPacketConstructor(packetSbScoreClass, lookup);
+            PACKET_SB_TEAM = FastReflection.findPacketConstructor(packetSbTeamClass, lookup);
+            PACKET_SB_SERIALIZABLE_TEAM = sbTeamClass == null ? null : FastReflection.findPacketConstructor(sbTeamClass, lookup);
+
+            for (Class<?> clazz : Arrays.asList(packetSbObjClass, packetSbDisplayObjClass, packetSbScoreClass, packetSbTeamClass, sbTeamClass)) {
+                if (clazz == null) {
+                    continue;
+                }
+                Field[] fields = Arrays.stream(clazz.getDeclaredFields())
+                        .filter(field -> !Modifier.isStatic(field.getModifiers()))
+                        .toArray(Field[]::new);
+                for (Field field : fields) {
+                    field.setAccessible(true);
+                }
+                PACKETS.put(clazz, fields);
+            }
+
+            if (VersionType.V1_8.isHigherOrEqual()) {
+                String enumSbActionClass = VersionType.V1_13.isHigherOrEqual()
+                        ? "ScoreboardServer$Action"
+                        : "PacketPlayOutScoreboardScore$EnumScoreboardAction";
+                ENUM_SB_HEALTH_DISPLAY = FastReflection.nmsClass("world.scores.criteria", "IScoreboardCriteria$EnumScoreboardHealthDisplay");
+                ENUM_SB_ACTION = FastReflection.nmsClass("server", enumSbActionClass);
+                ENUM_SB_HEALTH_DISPLAY_INTEGER = FastReflection.enumValueOf(ENUM_SB_HEALTH_DISPLAY, "INTEGER", 0);
+                ENUM_SB_ACTION_CHANGE = FastReflection.enumValueOf(ENUM_SB_ACTION, "CHANGE", 0);
+                ENUM_SB_ACTION_REMOVE = FastReflection.enumValueOf(ENUM_SB_ACTION, "REMOVE", 1);
+            } else {
+                ENUM_SB_HEALTH_DISPLAY = null;
+                ENUM_SB_ACTION = null;
+                ENUM_SB_HEALTH_DISPLAY_INTEGER = null;
+                ENUM_SB_ACTION_CHANGE = null;
+                ENUM_SB_ACTION_REMOVE = null;
+            }
+        } catch (Throwable t) {
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+
+    private final Player player;
+    private final String id;
+
+    private final List<T> lines = new ArrayList<>();
+    private T title = emptyLine();
+
+    private boolean deleted = false;
+
+    /**
+     * Creates a new FastBoard.
+     *
+     * @param player the owner of the scoreboard
+     */
+    protected FastBoardBase(Player player) {
+        this.player = Objects.requireNonNull(player, "player");
+        this.id = "fb-" + Integer.toHexString(ThreadLocalRandom.current().nextInt());
+
+        try {
+            sendObjectivePacket(ObjectiveMode.CREATE);
+            sendDisplayObjectivePacket();
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to create scoreboard", t);
+        }
+    }
+
+    /**
+     * Get the scoreboard title.
+     *
+     * @return the scoreboard title
+     */
+    public T getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Update the scoreboard title.
+     *
+     * @param title the new scoreboard title
+     * @throws IllegalArgumentException if the title is longer than 32 chars on 1.12 or lower
+     * @throws IllegalStateException    if {@link #delete()} was call before
+     */
+    public void updateTitle(T title) {
+        if (this.title.equals(Objects.requireNonNull(title, "title"))) {
+            return;
+        }
+
+        this.title = title;
+
+        try {
+            sendObjectivePacket(ObjectiveMode.UPDATE);
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to update scoreboard title", t);
+        }
+    }
+
+    /**
+     * Get the scoreboard lines.
+     *
+     * @return the scoreboard lines
+     */
+    public List<T> getLines() {
+        return new ArrayList<>(this.lines);
+    }
+
+    /**
+     * Get the specified scoreboard line.
+     *
+     * @param line the line number
+     * @return the line
+     * @throws IndexOutOfBoundsException if the line is higher than {@code size}
+     */
+    public T getLine(int line) {
+        checkLineNumber(line, true, false);
+
+        return this.lines.get(line);
+    }
+
+    /**
+     * Update a single scoreboard line.
+     *
+     * @param line the line number
+     * @param text the new line text
+     * @throws IndexOutOfBoundsException if the line is higher than {@link #size() size() + 1}
+     */
+    public synchronized void updateLine(int line, T text) {
+        checkLineNumber(line, false, true);
+
+        try {
+            if (line < size()) {
+                this.lines.set(line, text);
+
+                sendTeamPacket(getScoreByLine(line), TeamMode.UPDATE);
+                return;
+            }
+
+            List<T> newLines = new ArrayList<>(this.lines);
+
+            if (line > size()) {
+                for (int i = size(); i < line; i++) {
+                    newLines.add(emptyLine());
+                }
+            }
+
+            newLines.add(text);
+
+            updateLines(newLines);
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to update scoreboard lines", t);
+        }
+    }
+
+    /**
+     * Remove a scoreboard line.
+     *
+     * @param line the line number
+     */
+    public synchronized void removeLine(int line) {
+        checkLineNumber(line, false, false);
+
+        if (line >= size()) {
+            return;
+        }
+
+        List<T> newLines = new ArrayList<>(this.lines);
+        newLines.remove(line);
+        updateLines(newLines);
+    }
+
+    /**
+     * Update all the scoreboard lines.
+     *
+     * @param lines the new lines
+     * @throws IllegalArgumentException if one line is longer than 30 chars on 1.12 or lower
+     * @throws IllegalStateException    if {@link #delete()} was call before
+     */
+    public void updateLines(T... lines) {
+        updateLines(Arrays.asList(lines));
+    }
+
+    /**
+     * Update the lines of the scoreboard
+     *
+     * @param lines the new scoreboard lines
+     * @throws IllegalArgumentException if one line is longer than 30 chars on 1.12 or lower
+     * @throws IllegalStateException    if {@link #delete()} was call before
+     */
+    public synchronized void updateLines(Collection<T> lines) {
+        Objects.requireNonNull(lines, "lines");
+        checkLineNumber(lines.size(), false, true);
+
+        List<T> oldLines = new ArrayList<>(this.lines);
+        this.lines.clear();
+        this.lines.addAll(lines);
+
+        int linesSize = this.lines.size();
+
+        try {
+            if (oldLines.size() != linesSize) {
+                List<T> oldLinesCopy = new ArrayList<>(oldLines);
+
+                if (oldLines.size() > linesSize) {
+                    for (int i = oldLinesCopy.size(); i > linesSize; i--) {
+                        sendTeamPacket(i - 1, TeamMode.REMOVE);
+                        sendScorePacket(i - 1, ScoreboardAction.REMOVE);
+
+                        oldLines.remove(0);
+                    }
+                } else {
+                    for (int i = oldLinesCopy.size(); i < linesSize; i++) {
+                        sendScorePacket(i, ScoreboardAction.CHANGE);
+                        sendTeamPacket(i, TeamMode.CREATE, null, null);
+
+                        oldLines.add(oldLines.size() - i, getLineByScore(i));
+                    }
+                }
+            }
+
+            for (int i = 0; i < linesSize; i++) {
+                if (!Objects.equals(getLineByScore(oldLines, i), getLineByScore(i))) {
+                    sendLineChange(i);
+                }
+            }
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to update scoreboard lines", t);
+        }
+    }
+
+    /**
+     * Get the player who has the scoreboard.
+     *
+     * @return current player for this FastBoard
+     */
+    public Player getPlayer() {
+        return this.player;
+    }
+
+    /**
+     * Get the scoreboard id.
+     *
+     * @return the id
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Get if the scoreboard is deleted.
+     *
+     * @return true if the scoreboard is deleted
+     */
+    public boolean isDeleted() {
+        return this.deleted;
+    }
+
+    /**
+     * Get the scoreboard size (the number of lines).
+     *
+     * @return the size
+     */
+    public int size() {
+        return this.lines.size();
+    }
+
+    /**
+     * Delete this FastBoard, and will remove the scoreboard for the associated player if he is online.
+     * After this, all uses of {@link #updateLines} and {@link #updateTitle} will throw an {@link IllegalStateException}
+     *
+     * @throws IllegalStateException if this was already call before
+     */
+    public void delete() {
+        try {
+            for (int i = 0; i < this.lines.size(); i++) {
+                sendTeamPacket(i, TeamMode.REMOVE);
+            }
+
+            sendObjectivePacket(ObjectiveMode.REMOVE);
+        } catch (Throwable t) {
+            throw new RuntimeException("Unable to delete scoreboard", t);
+        }
+
+        this.deleted = true;
+    }
+
+    protected abstract void sendLineChange(int score) throws Throwable;
+
+    protected abstract Object toMinecraftComponent(T value) throws Throwable;
+
+    protected abstract T emptyLine();
+
+    private void checkLineNumber(int line, boolean checkInRange, boolean checkMax) {
+        if (line < 0) {
+            throw new IllegalArgumentException("Line number must be positive");
+        }
+
+        if (checkInRange && line >= this.lines.size()) {
+            throw new IllegalArgumentException("Line number must be under " + this.lines.size());
+        }
+
+        if (checkMax && line >= COLOR_CODES.length - 1) {
+            throw new IllegalArgumentException("Line number is too high: " + line);
+        }
+    }
+
+    protected int getScoreByLine(int line) {
+        return this.lines.size() - line - 1;
+    }
+
+    protected T getLineByScore(int score) {
+        return getLineByScore(this.lines, score);
+    }
+
+    protected T getLineByScore(List<T> lines, int score) {
+        return lines.get(lines.size() - score - 1);
+    }
+
+    protected void sendObjectivePacket(ObjectiveMode mode) throws Throwable {
+        Object packet = PACKET_SB_OBJ.invoke();
+
+        setField(packet, String.class, this.id);
+        setField(packet, int.class, mode.ordinal());
+
+        if (mode != ObjectiveMode.REMOVE) {
+            setComponentField(packet, this.title, 1);
+
+            if (VersionType.V1_8.isHigherOrEqual()) {
+                setField(packet, ENUM_SB_HEALTH_DISPLAY, ENUM_SB_HEALTH_DISPLAY_INTEGER);
+            }
+        } else if (VERSION_TYPE == VersionType.V1_7) {
+            setField(packet, String.class, "", 1);
+        }
+
+        sendPacket(packet);
+    }
+
+    protected void sendDisplayObjectivePacket() throws Throwable {
+        Object packet = PACKET_SB_DISPLAY_OBJ.invoke();
+
+        setField(packet, int.class, 1); // Position (1: sidebar)
+        setField(packet, String.class, this.id); // Score Name
+
+        sendPacket(packet);
+    }
+
+    protected void sendScorePacket(int score, ScoreboardAction action) throws Throwable {
+        Object packet = PACKET_SB_SCORE.invoke();
+
+        setField(packet, String.class, COLOR_CODES[score], 0); // Player Name
+
+        if (VersionType.V1_8.isHigherOrEqual()) {
+            Object enumAction = action == ScoreboardAction.REMOVE
+                    ? ENUM_SB_ACTION_REMOVE : ENUM_SB_ACTION_CHANGE;
+            setField(packet, ENUM_SB_ACTION, enumAction);
+        } else {
+            setField(packet, int.class, action.ordinal(), 1); // Action
+        }
+
+        if (action == ScoreboardAction.CHANGE) {
+            setField(packet, String.class, this.id, 1); // Objective Name
+            setField(packet, int.class, score); // Score
+        }
+
+        sendPacket(packet);
+    }
+
+    protected void sendTeamPacket(int score, TeamMode mode) throws Throwable {
+        sendTeamPacket(score, mode, null, null);
+    }
+
+    protected void sendTeamPacket(int score, TeamMode mode, T prefix, T suffix)
+            throws Throwable {
+        if (mode == TeamMode.ADD_PLAYERS || mode == TeamMode.REMOVE_PLAYERS) {
+            throw new UnsupportedOperationException();
+        }
+
+        Object packet = PACKET_SB_TEAM.invoke();
+
+        setField(packet, String.class, this.id + ':' + score); // Team name
+        setField(packet, int.class, mode.ordinal(), VERSION_TYPE == VersionType.V1_8 ? 1 : 0); // Update mode
+
+        if (mode == TeamMode.REMOVE) {
+            sendPacket(packet);
+            return;
+        }
+
+        if (VersionType.V1_17.isHigherOrEqual()) {
+            Object team = PACKET_SB_SERIALIZABLE_TEAM.invoke();
+            // Since the packet is initialized with null values, we need to change more things.
+            setComponentField(team, null, 0); // Display name
+            setField(team, CHAT_FORMAT_ENUM, RESET_FORMATTING); // Color
+            setComponentField(team, prefix, 1); // Prefix
+            setComponentField(team, suffix, 2); // Suffix
+            setField(team, String.class, "always", 0); // Visibility
+            setField(team, String.class, "always", 1); // Collisions
+            setField(packet, Optional.class, Optional.of(team));
+        } else {
+            setComponentField(packet, prefix, 2); // Prefix
+            setComponentField(packet, suffix, 3); // Suffix
+            setField(packet, String.class, "always", 4); // Visibility for 1.8+
+            setField(packet, String.class, "always", 5); // Collisions for 1.9+
+        }
+
+        if (mode == TeamMode.CREATE) {
+            setField(packet, Collection.class, Collections.singletonList(COLOR_CODES[score])); // Players in the team
+        }
+
+        sendPacket(packet);
+    }
+
+    private void sendPacket(Object packet) throws Throwable {
+        if (this.deleted) {
+            throw new IllegalStateException("This FastBoard is deleted");
+        }
+
+        if (this.player.isOnline()) {
+            Object entityPlayer = PLAYER_GET_HANDLE.invoke(this.player);
+            Object playerConnection = PLAYER_CONNECTION.invoke(entityPlayer);
+            SEND_PACKET.invoke(playerConnection, packet);
+        }
+    }
+
+    private void setField(Object object, Class<?> fieldType, Object value)
+            throws ReflectiveOperationException {
+        setField(object, fieldType, value, 0);
+    }
+
+    private void setField(Object packet, Class<?> fieldType, Object value, int count)
+            throws ReflectiveOperationException {
+        int i = 0;
+        for (Field field : PACKETS.get(packet.getClass())) {
+            if (field.getType() == fieldType && count == i++) {
+                field.set(packet, value);
+            }
+        }
+    }
+
+    private void setComponentField(Object packet, T value, int count) throws Throwable {
+        if (!VersionType.V1_13.isHigherOrEqual()) {
+            setField(packet, String.class, value, count);
+            return;
+        }
+
+        int i = 0;
+        for (Field field : PACKETS.get(packet.getClass())) {
+            if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
+                field.set(packet, toMinecraftComponent(value));
+            }
+        }
+    }
+
+    public enum ObjectiveMode {
+        CREATE, REMOVE, UPDATE
+    }
+
+    public enum TeamMode {
+        CREATE, REMOVE, UPDATE, ADD_PLAYERS, REMOVE_PLAYERS
+    }
+
+    public enum ScoreboardAction {
+        CHANGE, REMOVE
+    }
+
+    enum VersionType {
+        V1_7, V1_8, V1_13, V1_17;
+
+        public boolean isHigherOrEqual() {
+            return VERSION_TYPE.ordinal() >= ordinal();
+        }
+    }
+}

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FastBoard, licensed under the MIT License.
  *
- * Copyright (c) 2019-2021 MrMicky
+ * Copyright (c) 2019-2023 MrMicky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
  *
  * @author MrMicky
- * @version 2.0.0-SNAPSHOT
+ * @version 2.0.0
  */
 public abstract class FastBoardBase<T> {
 

--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FastBoard, licensed under the MIT License.
  *
- * Copyright (c) 2019-2021 MrMicky
+ * Copyright (c) 2019-2023 MrMicky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -1,0 +1,80 @@
+/*
+ * This file is part of FastBoard, licensed under the MIT License.
+ *
+ * Copyright (c) 2019-2021 MrMicky
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package fr.mrmicky.fastboard.adventure;
+
+import fr.mrmicky.fastboard.FastBoardBase;
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+/**
+ * {@inheritDoc}
+ */
+public class FastBoard extends FastBoardBase<Component> {
+
+    private static final MethodHandle AS_VANILLA;
+    private static final Object EMPTY_COMPONENT;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            Class<?> paperAdventure = Class.forName("io.papermc.paper.adventure.PaperAdventure");
+            Method method = paperAdventure.getDeclaredMethod("asVanilla", Component.class);
+            AS_VANILLA = lookup.unreflect(method);
+            EMPTY_COMPONENT = AS_VANILLA.invoke(Component.empty());
+        } catch (Throwable t) {
+            throw new ExceptionInInitializerError(t);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public FastBoard(Player player) {
+        super(player);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void sendLineChange(int score) throws Throwable {
+        Component line = getLineByScore(score);
+
+        sendTeamPacket(score, FastBoardBase.TeamMode.UPDATE, line, null);
+    }
+
+    @Override
+    protected Object toMinecraftComponent(Component component) throws Throwable {
+        return component != null ? AS_VANILLA.invoke(component) : EMPTY_COMPONENT;
+    }
+
+    @Override
+    protected Component emptyLine() {
+        return Component.empty();
+    }
+}

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of FastBoard, licensed under the MIT License.
  *
- * Copyright (c) 2019-2021 MrMicky
+ * Copyright (c) 2019-2023 MrMicky
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
+++ b/src/main/java/fr/mrmicky/fastboard/adventure/FastBoard.java
@@ -24,11 +24,14 @@
 package fr.mrmicky.fastboard.adventure;
 
 import fr.mrmicky.fastboard.FastBoardBase;
+import fr.mrmicky.fastboard.FastReflection;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Player;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 
 /**
@@ -36,16 +39,27 @@ import java.lang.reflect.Method;
  */
 public class FastBoard extends FastBoardBase<Component> {
 
-    private static final MethodHandle AS_VANILLA;
+    private static final MethodHandle COMPONENT_METHOD;
     private static final Object EMPTY_COMPONENT;
+    private static final boolean ADVENTURE_SUPPORT;
 
     static {
+        ADVENTURE_SUPPORT = FastReflection
+                .optionalClass("io.papermc.paper.adventure.PaperAdventure")
+                .isPresent();
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+
         try {
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            Class<?> paperAdventure = Class.forName("io.papermc.paper.adventure.PaperAdventure");
-            Method method = paperAdventure.getDeclaredMethod("asVanilla", Component.class);
-            AS_VANILLA = lookup.unreflect(method);
-            EMPTY_COMPONENT = AS_VANILLA.invoke(Component.empty());
+            if (ADVENTURE_SUPPORT) {
+                Class<?> paperAdventure = Class.forName("io.papermc.paper.adventure.PaperAdventure");
+                Method method = paperAdventure.getDeclaredMethod("asVanilla", Component.class);
+                COMPONENT_METHOD = lookup.unreflect(method);
+                EMPTY_COMPONENT = COMPONENT_METHOD.invoke(Component.empty());
+            } else {
+                Class<?> craftChatMessageClass = FastReflection.obcClass("util.CraftChatMessage");
+                COMPONENT_METHOD = lookup.unreflect(craftChatMessageClass.getMethod("fromString", String.class));
+                EMPTY_COMPONENT = Array.get(COMPONENT_METHOD.invoke(""), 0);
+            }
         } catch (Throwable t) {
             throw new ExceptionInInitializerError(t);
         }
@@ -70,7 +84,19 @@ public class FastBoard extends FastBoardBase<Component> {
 
     @Override
     protected Object toMinecraftComponent(Component component) throws Throwable {
-        return component != null ? AS_VANILLA.invoke(component) : EMPTY_COMPONENT;
+        if (component == null) {
+            return EMPTY_COMPONENT;
+        }
+
+        // If the server isn't running adventure natively, we convert the component to legacy text
+        // and then to a Minecraft chat component
+        if (!ADVENTURE_SUPPORT) {
+            String legacy = LegacyComponentSerializer.legacySection().serialize(component);
+
+            return Array.get(COMPONENT_METHOD.invoke(legacy), 0);
+        }
+
+        return COMPONENT_METHOD.invoke(component);
     }
 
     @Override


### PR DESCRIPTION
This new version adds optional support for [Kyori Adventure components](https://github.com/KyoriPowered/adventure) for title/lines in the class `fr.mrmicky.fastboard.adventure.FastBoard`.

The current String-based version of FastBoard can still be used with the class `fr.mrmicky.fastboard.FastBoard`.

The only required change should be to include the new `FastBoardBase` class when including FastBoard manually in a project.

For Maven/Gradle, this version is already available on Sonatype OSS, see the README of this branch.

Feel free to comment if you have any suggestions/issues :)

Closes #7