### PR TITLE
Add support for 1.20.2 servers

### DIFF
--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -119,7 +119,7 @@ public abstract class FastBoardBase<T> {
 
             CHAT_COMPONENT_CLASS = FastReflection.nmsClass("network.chat", "IChatBaseComponent");
             CHAT_FORMAT_ENUM = FastReflection.nmsClass(null, "EnumChatFormat");
-            DISPLAY_SLOT_ENUM = FastReflection.nullableNmsClass("world.scores", "DisplaySlot");
+            DISPLAY_SLOT_ENUM = FastReflection.nmsOptionalClass("world.scores", "DisplaySlot").orElse(null);
             RESET_FORMATTING = FastReflection.enumValueOf(CHAT_FORMAT_ENUM, "RESET", 21);
             SIDEBAR_DISPLAY_SLOT = DISPLAY_SLOT_ENUM == null ? null : FastReflection.enumValueOf(DISPLAY_SLOT_ENUM, "SIDEBAR", 1);
             PLAYER_GET_HANDLE = lookup.findVirtual(craftPlayerClass, "getHandle", MethodType.methodType(entityPlayerClass));

--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -70,14 +70,6 @@ public final class FastReflection {
         return Class.forName(nmsClassName(post1_17package, className));
     }
 
-    public static Class<?> nullableNmsClass(String post1_17package, String className) {
-        try {
-            return nmsClass(post1_17package, className);
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
-    }
-
     public static Optional<Class<?>> nmsOptionalClass(String post1_17package, String className) {
         return optionalClass(nmsClassName(post1_17package, className));
     }

--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -70,6 +70,14 @@ public final class FastReflection {
         return Class.forName(nmsClassName(post1_17package, className));
     }
 
+    public static Class<?> nullableNmsClass(String post1_17package, String className) {
+        try {
+            return nmsClass(post1_17package, className);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
     public static Optional<Class<?>> nmsOptionalClass(String post1_17package, String className) {
         return optionalClass(nmsClassName(post1_17package, className));
     }


### PR DESCRIPTION
Minecraft 1.20.2 introduces a `bool PlayerConnection#shouldHandleMessage(Packet<?>)` method that is matched instead of `#sendPacket(Packet<?>)` of the super class.

The second breaking change is that the display slot is now an enum, so the packet construction has been modified accordingly.