### PR TITLE
Add support for 1.20.3 servers

### DIFF
--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -70,11 +70,12 @@ public abstract class FastBoardBase<T> {
     // Scoreboard packets
     private static final FastReflection.PacketConstructor PACKET_SB_OBJ;
     private static final FastReflection.PacketConstructor PACKET_SB_DISPLAY_OBJ;
-    private static final FastReflection.PacketConstructor PACKET_SB_SCORE;
+    private static final MethodHandle PACKET_SB_SCORE;
     private static final FastReflection.PacketConstructor PACKET_SB_TEAM;
     private static final FastReflection.PacketConstructor PACKET_SB_SERIALIZABLE_TEAM;
     // Scoreboard enums
     private static final Class<?> DISPLAY_SLOT_TYPE;
+    private static final Class<?> NUMBER_FORMAT_INTERFACE;
     private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
     private static final Class<?> ENUM_SB_ACTION;
     private static final Object SIDEBAR_DISPLAY_SLOT;
@@ -116,6 +117,12 @@ public abstract class FastBoardBase<T> {
                     )
                     .filter(m -> m.getParameterCount() == 1 && m.getParameterTypes()[0] == packetClass)
                     .findFirst().orElseThrow(NoSuchMethodException::new);
+            Class<?> numberFormat = null;
+            try {
+                numberFormat = FastReflection.nmsClass("network.chat.numbers", "NumberFormat");
+            } catch (ClassNotFoundException ignored) { // 1.20.2-
+            }
+            NUMBER_FORMAT_INTERFACE = numberFormat;
 
             Optional<Class<?>> displaySlotEnum = FastReflection.nmsOptionalClass("world.scores", "DisplaySlot");
             CHAT_COMPONENT_CLASS = FastReflection.nmsClass("network.chat", "IChatBaseComponent");
@@ -128,7 +135,18 @@ public abstract class FastBoardBase<T> {
             SEND_PACKET = lookup.unreflect(sendPacketMethod);
             PACKET_SB_OBJ = FastReflection.findPacketConstructor(packetSbObjClass, lookup);
             PACKET_SB_DISPLAY_OBJ = FastReflection.findPacketConstructor(packetSbDisplayObjClass, lookup);
-            PACKET_SB_SCORE = FastReflection.findPacketConstructor(packetSbScoreClass, lookup);
+            MethodHandle packetSbScore;
+            if (VersionType.V1_17.isHigherOrEqual()) {
+                if (numberFormat != null) { // 1.20.3+
+                    packetSbScore = lookup.findConstructor(packetSbScoreClass, MethodType.methodType(void.class, String.class, String.class, int.class, CHAT_COMPONENT_CLASS, numberFormat));
+                } else { // 1.20.2-
+                    Class<?> enumSbAction = FastReflection.nmsClass("server", "ScoreboardServer$Action");
+                    packetSbScore = lookup.findConstructor(packetSbScoreClass, MethodType.methodType(void.class, enumSbAction, String.class, String.class, int.class));
+                }
+            } else {
+                packetSbScore = lookup.findConstructor(packetSbScoreClass, MethodType.methodType(void.class));
+            }
+            PACKET_SB_SCORE = packetSbScore;
             PACKET_SB_TEAM = FastReflection.findPacketConstructor(packetSbTeamClass, lookup);
             PACKET_SB_SERIALIZABLE_TEAM = sbTeamClass == null ? null : FastReflection.findPacketConstructor(sbTeamClass, lookup);
 
@@ -470,13 +488,24 @@ public abstract class FastBoardBase<T> {
     }
 
     protected void sendScorePacket(int score, ScoreboardAction action) throws Throwable {
+        Object enumAction = action == ScoreboardAction.REMOVE
+                ? ENUM_SB_ACTION_REMOVE : ENUM_SB_ACTION_CHANGE;
+        if (VersionType.V1_17.isHigherOrEqual()) {
+            Object packet;
+            if (NUMBER_FORMAT_INTERFACE != null) { // 1.20.3+
+                packet = PACKET_SB_SCORE.invoke(COLOR_CODES[score], this.id, score, null, null);
+            } else {
+                packet = PACKET_SB_SCORE.invoke(enumAction, this.id, COLOR_CODES[score], score);
+            }
+            sendPacket(packet);
+            return;
+        }
+
         Object packet = PACKET_SB_SCORE.invoke();
 
         setField(packet, String.class, COLOR_CODES[score], 0); // Player Name
 
         if (VersionType.V1_8.isHigherOrEqual()) {
-            Object enumAction = action == ScoreboardAction.REMOVE
-                    ? ENUM_SB_ACTION_REMOVE : ENUM_SB_ACTION_CHANGE;
             setField(packet, ENUM_SB_ACTION, enumAction);
         } else {
             setField(packet, int.class, action.ordinal(), 1); // Action


### PR DESCRIPTION
The [`PacketPlayOutScoreboardScore`](https://mappings.cephx.dev/1.20.2/net/minecraft/network/protocol/game/ClientboundSetScorePacket.html) class is now split into two records, [`ClientboundSetScorePacket`](https://mappings.cephx.dev/1.20.3/net/minecraft/network/protocol/game/ClientboundSetScorePacket.html) and [`ClientboundResetScorePacket`](https://mappings.cephx.dev/1.20.3/net/minecraft/network/protocol/game/ClientboundResetScorePacket.html).

Record fields cannot be modified via reflection, so it uses the packet constructors directly. It adds a lot of code for a minor version, class detection was the best method I could think of.

- Fixes #42