### PR TITLE
Add support for 1.20.5 servers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 11, 17]
+        java-version: [8, 11, 17, 21]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Lightweight packet-based scoreboard API for Bukkit plugins, with 1.7.10 to 1.20.
     <dependency>
         <groupId>fr.mrmicky</groupId>
         <artifactId>fastboard</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
     </dependency>
 </dependencies>
 ```
@@ -79,7 +79,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:2.1.0'
+    implementation 'fr.mrmicky:fastboard:2.1.1'
 }
 
 shadowJar {

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.5-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.mrmicky</groupId>
     <artifactId>fastboard</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <name>FastBoard</name>
     <description>Lightweight packet-based scoreboard API for Bukkit plugins.</description>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.20.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -141,10 +141,10 @@ public abstract class FastBoardBase<T> {
                 MethodType fixedFormatType = MethodType.methodType(void.class, CHAT_COMPONENT_CLASS);
                 Optional<Field> blankField = Arrays.stream(blankFormatClass.getFields()).filter(f -> f.getType() == blankFormatClass).findAny();
                 // Fields are of type Optional in 1.20.5+
-                Optional<MethodHandle> optionalScorePacket = FastReflection.optionalConstructor(packetSbScoreClass, lookup, scoreType);
+                Optional<MethodHandle> optionalScorePacket = FastReflection.optionalConstructor(packetSbScoreClass, lookup, scoreTypeOptional);
                 fixedFormatConstructor = lookup.findConstructor(fixedFormatClass, fixedFormatType);
                 packetSbSetScore = optionalScorePacket.isPresent() ? optionalScorePacket.get()
-                        : lookup.findConstructor(packetSbScoreClass, scoreTypeOptional);
+                        : lookup.findConstructor(packetSbScoreClass, scoreType);
                 scoreOptionalComponents = optionalScorePacket.isPresent();
                 packetSbResetScore = lookup.findConstructor(resetScoreClass, removeScoreType);
                 blankNumberFormat = blankField.isPresent() ? blankField.get().get(null) : null;

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
  *
  * @author MrMicky
- * @version 2.1.0
+ * @version 2.1.1
  */
 public abstract class FastBoardBase<T> {
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -67,7 +67,7 @@ public abstract class FastBoardBase<T> {
     private static final FastReflection.PacketConstructor PACKET_SB_SERIALIZABLE_TEAM;
     private static final MethodHandle PACKET_SB_SET_SCORE;
     private static final MethodHandle PACKET_SB_RESET_SCORE;
-    private static final boolean USE_OPTIONAL_COMPONENT;
+    private static final boolean SCORE_OPTIONAL_COMPONENTS;
     // Scoreboard enums
     private static final Class<?> DISPLAY_SLOT_TYPE;
     private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
@@ -129,25 +129,23 @@ public abstract class FastBoardBase<T> {
             MethodHandle packetSbResetScore = null;
             MethodHandle fixedFormatConstructor = null;
             Object blankNumberFormat = null;
-            boolean useOptional = false;
+            boolean scoreOptionalComponents = false;
 
             if (numberFormat.isPresent()) { // 1.20.3
                 Class<?> blankFormatClass = FastReflection.nmsClass("network.chat.numbers", "BlankFormat");
                 Class<?> fixedFormatClass = FastReflection.nmsClass("network.chat.numbers", "FixedFormat");
                 Class<?> resetScoreClass = FastReflection.nmsClass(gameProtocolPackage, "ClientboundResetScorePacket");
-                MethodType setScoreType = MethodType.methodType(void.class, String.class, String.class, int.class, CHAT_COMPONENT_CLASS, numberFormat.get());
-                MethodType setScoreTypeOpt = MethodType.methodType(void.class, String.class, String.class, int.class, Optional.class, Optional.class);
+                MethodType scoreType = MethodType.methodType(void.class, String.class, String.class, int.class, CHAT_COMPONENT_CLASS, numberFormat.get());
+                MethodType scoreTypeOptional = MethodType.methodType(void.class, String.class, String.class, int.class, Optional.class, Optional.class);
                 MethodType removeScoreType = MethodType.methodType(void.class, String.class, String.class);
                 MethodType fixedFormatType = MethodType.methodType(void.class, CHAT_COMPONENT_CLASS);
                 Optional<Field> blankField = Arrays.stream(blankFormatClass.getFields()).filter(f -> f.getType() == blankFormatClass).findAny();
-                Optional<MethodHandle> packetSbSetScoreNull = FastReflection.optionalConstructor(packetSbScoreClass, lookup, setScoreType);
+                // Fields are of type Optional in 1.20.5+
+                Optional<MethodHandle> optionalScorePacket = FastReflection.optionalConstructor(packetSbScoreClass, lookup, scoreType);
                 fixedFormatConstructor = lookup.findConstructor(fixedFormatClass, fixedFormatType);
-                if (packetSbSetScoreNull.isPresent()) {
-                    packetSbSetScore = packetSbSetScoreNull.get();
-                } else { // 1.20.5
-                    packetSbSetScore = lookup.findConstructor(packetSbScoreClass, setScoreTypeOpt);
-                    useOptional = true;
-                }
+                packetSbSetScore = optionalScorePacket.isPresent() ? optionalScorePacket.get()
+                        : lookup.findConstructor(packetSbScoreClass, scoreTypeOptional);
+                scoreOptionalComponents = optionalScorePacket.isPresent();
                 packetSbResetScore = lookup.findConstructor(resetScoreClass, removeScoreType);
                 blankNumberFormat = blankField.isPresent() ? blankField.get().get(null) : null;
             } else if (VersionType.V1_17.isHigherOrEqual()) {
@@ -164,7 +162,7 @@ public abstract class FastBoardBase<T> {
             PACKET_SB_SERIALIZABLE_TEAM = sbTeamClass == null ? null : FastReflection.findPacketConstructor(sbTeamClass, lookup);
             FIXED_NUMBER_FORMAT = fixedFormatConstructor;
             BLANK_NUMBER_FORMAT = blankNumberFormat;
-            USE_OPTIONAL_COMPONENT = useOptional;
+            SCORE_OPTIONAL_COMPONENTS = scoreOptionalComponents;
 
             for (Class<?> clazz : Arrays.asList(packetSbObjClass, packetSbDisplayObjClass, packetSbScoreClass, packetSbTeamClass, sbTeamClass)) {
                 if (clazz == null) {
@@ -633,7 +631,7 @@ public abstract class FastBoardBase<T> {
 
         if (mode != ObjectiveMode.REMOVE) {
             setComponentField(packet, this.title, 1);
-            setField(packet, Optional.class, Optional.empty()); // Number format 1.20.5, previously nullable
+            setField(packet, Optional.class, Optional.empty()); // Number format for 1.20.5+, previously nullable
 
             if (VersionType.V1_8.isHigherOrEqual()) {
                 setField(packet, ENUM_SB_HEALTH_DISPLAY, ENUM_SB_HEALTH_DISPLAY_INTEGER);
@@ -699,12 +697,11 @@ public abstract class FastBoardBase<T> {
         Object format = scoreFormat != null
                 ? FIXED_NUMBER_FORMAT.invoke(toMinecraftComponent(scoreFormat))
                 : BLANK_NUMBER_FORMAT;
+        Object scorePacket = SCORE_OPTIONAL_COMPONENTS
+                ? PACKET_SB_SET_SCORE.invoke(objName, this.id, score, Optional.empty(), Optional.of(format))
+                : PACKET_SB_SET_SCORE.invoke(objName, this.id, score, null, format);
 
-        if (USE_OPTIONAL_COMPONENT) {
-            sendPacket(PACKET_SB_SET_SCORE.invoke(objName, this.id, score, Optional.empty(), Optional.of(format)));
-        } else {
-            sendPacket(PACKET_SB_SET_SCORE.invoke(objName, this.id, score, null, format));
-        }
+        sendPacket(scorePacket);
     }
 
     protected void sendTeamPacket(int score, TeamMode mode) throws Throwable {

--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -119,6 +119,14 @@ public final class FastReflection {
         throw new ClassNotFoundException("No class in " + parentClass.getCanonicalName() + " matches the predicate.");
     }
 
+    static Optional<MethodHandle> optionalConstructor(Class<?> declaringClass, MethodHandles.Lookup lookup, MethodType methodType) throws IllegalAccessException {
+        try {
+            return Optional.of(lookup.findConstructor(declaringClass, methodType));
+        } catch (NoSuchMethodException e) {
+            return Optional.empty();
+        }
+    }
+
     public static PacketConstructor findPacketConstructor(Class<?> packetClass, MethodHandles.Lookup lookup) throws Exception {
         try {
             MethodHandle constructor = lookup.findConstructor(packetClass, VOID_METHOD_TYPE);

--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -119,9 +119,9 @@ public final class FastReflection {
         throw new ClassNotFoundException("No class in " + parentClass.getCanonicalName() + " matches the predicate.");
     }
 
-    static Optional<MethodHandle> optionalConstructor(Class<?> declaringClass, MethodHandles.Lookup lookup, MethodType methodType) throws IllegalAccessException {
+    static Optional<MethodHandle> optionalConstructor(Class<?> declaringClass, MethodHandles.Lookup lookup, MethodType type) throws IllegalAccessException {
         try {
-            return Optional.of(lookup.findConstructor(declaringClass, methodType));
+            return Optional.of(lookup.findConstructor(declaringClass, type));
         } catch (NoSuchMethodException e) {
             return Optional.empty();
         }


### PR DESCRIPTION
The [`ClientboundSetScorePacket`](https://mappings.cephx.dev/1.20.5/net/minecraft/network/protocol/game/ClientboundSetScorePacket.html) and [`ClientboundSetObjectivePacket`](https://mappings.cephx.dev/1.20.5/net/minecraft/network/protocol/game/ClientboundSetObjectivePacket.html) classes now use `Optional` instead of `null`.

This PR uses the fact that the `setField` method will silently fail if there is no field with this type.

Tested on a fresh Spigot 1.20.5 build, and on Paper 1.20.4.