### PR TITLE
Adapt FastReflection for Paper 1.20.5

### DIFF
--- a/src/main/java/fr/mrmicky/fastboard/FastReflection.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastReflection.java
@@ -42,8 +42,9 @@ public final class FastReflection {
     private static final String NM_PACKAGE = "net.minecraft";
     public static final String OBC_PACKAGE = "org.bukkit.craftbukkit";
     public static final String NMS_PACKAGE = NM_PACKAGE + ".server";
+    private static final String OBC_PREFIX = Bukkit.getServer().getClass().getPackage().getName();
 
-    public static final String VERSION = Bukkit.getServer().getClass().getPackage().getName().substring(OBC_PACKAGE.length() + 1);
+    public static final String VERSION = getServerVersion();
 
     private static final MethodType VOID_METHOD_TYPE = MethodType.methodType(void.class);
     private static final boolean NMS_REPACKAGED = optionalClass(NM_PACKAGE + ".network.protocol.Packet").isPresent();
@@ -75,7 +76,7 @@ public final class FastReflection {
     }
 
     public static String obcClassName(String className) {
-        return OBC_PACKAGE + '.' + VERSION + '.' + className;
+        return OBC_PREFIX + '.' + className;
     }
 
     public static Class<?> obcClass(String className) throws ClassNotFoundException {
@@ -125,6 +126,18 @@ public final class FastReflection {
         } catch (NoSuchMethodException e) {
             return Optional.empty();
         }
+    }
+
+    private static String getServerVersion() {
+        Class<?> server = Bukkit.getServer().getClass();
+        if (!server.getSimpleName().equals("CraftServer")) {
+            return "";
+        }
+        if (server.getPackage().getName().equals(OBC_PACKAGE)) {
+            return "";
+        }
+        String version = server.getName().substring("org.bukkit.craftbukkit.".length());
+        return version.substring(0, version.length() - ".CraftServer".length());
     }
 
     public static PacketConstructor findPacketConstructor(Class<?> packetClass, MethodHandles.Lookup lookup) throws Exception {


### PR DESCRIPTION
Paper brought the end of the [CraftBukkit package relocation](https://forums.papermc.io/threads/paper-velocity-1-20-4.998/#post-2955). I guess I shouldn't have tested without a modified `FastReflection` class in my own plugin for #50.

The `VERSION` field is now an empty string on Paper 1.20.5, or on servers that have already previously disabled the relocation. I kept the `OBC_PACKAGE` static field because it is `public`, and some plugins may rely on it.

Tested on Paper 1.20.5, Paper 1.20.4 and Spigot 1.8.3, without Adventure.

- Fixes #52