### PR TITLE
Update README: Reflect Shadow Plugin Changes and Kotlin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,9 @@ Lightweight packet-based scoreboard API for Bukkit plugins, compatible with all 
 
 ### Gradle
 
-```kotlin
+```groovy
 plugins {
-    id ("java")
-    id ("com.gradleup.shadow") version "8.3.0"
+    id 'com.gradleup.shadow' version '8.3.0'
 }
 
 repositories {
@@ -81,12 +80,12 @@ repositories {
 }
 
 dependencies {
-    implementation("fr.mrmicky:fastboard:2.1.3")
+    implementation 'fr.mrmicky:fastboard:2.1.3'
 }
 
-tasks.shadowJar {
-    // Replace 'com.yourpackage' with the package of your plugin
-    relocate("fr.mrmicky.fastboard", "com.yourpackage.fastboard")
+shadowJar {
+    // Replace 'com.yourpackage' with the package of your plugin 
+    relocate 'fr.mrmicky.fastboard', 'com.yourpackage.fastboard'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ Lightweight packet-based scoreboard API for Bukkit plugins, compatible with all 
 
 ### Gradle
 
-```groovy
+```kotlin
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id ("java")
+    id ("com.gradleup.shadow") version "8.3.0"
 }
 
 repositories {
@@ -80,12 +81,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:2.1.3'
+    implementation("fr.mrmicky:fastboard:2.1.3")
 }
 
-shadowJar {
-    // Replace 'com.yourpackage' with the package of your plugin 
-    relocate 'fr.mrmicky.fastboard', 'com.yourpackage.fastboard'
+tasks.shadowJar {
+    // Replace 'com.yourpackage' with the package of your plugin
+    relocate("fr.mrmicky.fastboard", "com.yourpackage.fastboard")
 }
 ```
 


### PR DESCRIPTION
Hey!

While working on relocating FastBoard with Java 21, I encountered an issue where the shadow plugin doesn't support Java 21. During my search for a compatible version, I discovered that the package has been moved from `com.github.johnrengelman.shadow` to `com.gradleup.shadow` starting from version 8.3.0. To help others avoid this issue, I thought it would be helpful to update the README to reflect this change. Additionally, since Gradle uses Kotlin DSL as the default (as mentioned in [this article](https://blog.jetbrains.com/kotlin/2023/04/kotlin-dsl-is-the-default-for-new-gradle-builds/)), I've also updated the README accordingly.

Thanks for all your hard work! ❤️

Best,  
Sam