### PR TITLE
Add support for Minecraft 1.21.5 (fix #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Lightweight packet-based scoreboard API for Bukkit plugins, compatible with all 
     <dependency>
         <groupId>fr.mrmicky</groupId>
         <artifactId>fastboard</artifactId>
-        <version>2.1.3</version>
+        <version>2.1.4</version>
     </dependency>
 </dependencies>
 ```
@@ -80,7 +80,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'fr.mrmicky:fastboard:2.1.3'
+    implementation 'fr.mrmicky:fastboard:2.1.4'
 }
 
 shadowJar {

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.mrmicky</groupId>
     <artifactId>fastboard</artifactId>
-    <version>2.1.3</version>
+    <version>2.1.4</version>
 
     <name>FastBoard</name>
     <description>Lightweight packet-based scoreboard API for Bukkit plugins.</description>

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -72,14 +72,14 @@ public abstract class FastBoardBase<T> {
     private static final Class<?> DISPLAY_SLOT_TYPE;
     private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
     private static final Class<?> ENUM_SB_ACTION;
-    private static final Class<?> ENUM_NAME_TAG_VISIBILITY;
+    private static final Class<?> ENUM_VISIBILITY;
     private static final Class<?> ENUM_COLLISION_RULE;
     private static final Object BLANK_NUMBER_FORMAT;
     private static final Object SIDEBAR_DISPLAY_SLOT;
     private static final Object ENUM_SB_HEALTH_DISPLAY_INTEGER;
     private static final Object ENUM_SB_ACTION_CHANGE;
     private static final Object ENUM_SB_ACTION_REMOVE;
-    private static final Object ENUM_NAME_TAG_VISIBILITY_ALWAYS;
+    private static final Object ENUM_VISIBILITY_ALWAYS;
     private static final Object ENUM_COLLISION_RULE_ALWAYS;
 
     static {
@@ -170,20 +170,17 @@ public abstract class FastBoardBase<T> {
             BLANK_NUMBER_FORMAT = blankNumberFormat;
             SCORE_OPTIONAL_COMPONENTS = scoreOptionalComponents;
 
-            Object nameTagVisibilityAlways = "always";
-            Object collisionRuleAlways = "always";
-            if (sbTeamClass != null) {
-                Class<?> nameTagVisibilityClass = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumNameTagVisibility", "Team$Visibility");
-                Class<?> collisionRuleClass = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumTeamPush", "Team$CollisionRule");
-                if (Arrays.stream(sbTeamClass.getDeclaredFields()).anyMatch(field -> field.getType().equals(nameTagVisibilityClass))) { // 1.21.5+
-                    nameTagVisibilityAlways = FastReflection.enumValueOf(nameTagVisibilityClass, "ALWAYS", 0);
-                    collisionRuleAlways = FastReflection.enumValueOf(collisionRuleClass, "ALWAYS", 0);
-                }
+            if (VersionType.V1_17.isHigherOrEqual()) {
+                ENUM_VISIBILITY = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumNameTagVisibility", "Team$Visibility");
+                ENUM_COLLISION_RULE = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumTeamPush", "Team$CollisionRule");
+                ENUM_VISIBILITY_ALWAYS = FastReflection.enumValueOf(ENUM_VISIBILITY, "ALWAYS", 0);
+                ENUM_COLLISION_RULE_ALWAYS = FastReflection.enumValueOf(ENUM_COLLISION_RULE, "ALWAYS", 0);
+            } else {
+                ENUM_VISIBILITY = null;
+                ENUM_COLLISION_RULE = null;
+                ENUM_VISIBILITY_ALWAYS = null;
+                ENUM_COLLISION_RULE_ALWAYS = null;
             }
-            ENUM_NAME_TAG_VISIBILITY = nameTagVisibilityAlways.getClass();
-            ENUM_COLLISION_RULE = collisionRuleAlways.getClass();
-            ENUM_NAME_TAG_VISIBILITY_ALWAYS = nameTagVisibilityAlways;
-            ENUM_COLLISION_RULE_ALWAYS = collisionRuleAlways;
 
             for (Class<?> clazz : Arrays.asList(packetSbObjClass, packetSbDisplayObjClass, packetSbScoreClass, packetSbTeamClass, sbTeamClass)) {
                 if (clazz == null) {
@@ -752,9 +749,10 @@ public abstract class FastBoardBase<T> {
             setField(team, CHAT_FORMAT_ENUM, RESET_FORMATTING); // Color
             setComponentField(team, prefix, 1); // Prefix
             setComponentField(team, suffix, 2); // Suffix
-            setField(team, ENUM_NAME_TAG_VISIBILITY, ENUM_NAME_TAG_VISIBILITY_ALWAYS, 0);
-            int collisionRuleIndex = ENUM_NAME_TAG_VISIBILITY.equals(ENUM_COLLISION_RULE) ? 1 : 0; // Separated enums for 1.21.5+
-            setField(team, ENUM_COLLISION_RULE, ENUM_COLLISION_RULE_ALWAYS, collisionRuleIndex);
+            setField(team, String.class, "always", 0); // Visibility before 1.21.5
+            setField(team, String.class, "always", 1); // Collisions before 1.21.5
+            setField(team, ENUM_VISIBILITY, ENUM_VISIBILITY_ALWAYS, 0); // 1.21.5+
+            setField(team, ENUM_COLLISION_RULE, ENUM_COLLISION_RULE_ALWAYS, 0); // 1.21.5+
             setField(packet, Optional.class, Optional.of(team));
         } else {
             setComponentField(packet, prefix, 2); // Prefix

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
  * The project is on <a href="https://github.com/MrMicky-FR/FastBoard">GitHub</a>.
  *
  * @author MrMicky
- * @version 2.1.3
+ * @version 2.1.4
  */
 public abstract class FastBoardBase<T> {
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -72,11 +72,15 @@ public abstract class FastBoardBase<T> {
     private static final Class<?> DISPLAY_SLOT_TYPE;
     private static final Class<?> ENUM_SB_HEALTH_DISPLAY;
     private static final Class<?> ENUM_SB_ACTION;
+    private static final Class<?> ENUM_NAME_TAG_VISIBILITY;
+    private static final Class<?> ENUM_COLLISION_RULE;
     private static final Object BLANK_NUMBER_FORMAT;
     private static final Object SIDEBAR_DISPLAY_SLOT;
     private static final Object ENUM_SB_HEALTH_DISPLAY_INTEGER;
     private static final Object ENUM_SB_ACTION_CHANGE;
     private static final Object ENUM_SB_ACTION_REMOVE;
+    private static final Object ENUM_NAME_TAG_VISIBILITY_ALWAYS;
+    private static final Object ENUM_COLLISION_RULE_ALWAYS;
 
     static {
         try {
@@ -165,6 +169,21 @@ public abstract class FastBoardBase<T> {
             FIXED_NUMBER_FORMAT = fixedFormatConstructor;
             BLANK_NUMBER_FORMAT = blankNumberFormat;
             SCORE_OPTIONAL_COMPONENTS = scoreOptionalComponents;
+
+            Object nameTagVisibilityAlways = "always";
+            Object collisionRuleAlways = "always";
+            if (sbTeamClass != null) {
+                Class<?> nameTagVisibilityClass = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumNameTagVisibility", "Team$Visibility");
+                Class<?> collisionRuleClass = FastReflection.nmsClass("world.scores", "ScoreboardTeamBase$EnumTeamPush", "Team$CollisionRule");
+                if (Arrays.stream(sbTeamClass.getDeclaredFields()).anyMatch(field -> field.getType().equals(nameTagVisibilityClass))) { // 1.21.5+
+                    nameTagVisibilityAlways = FastReflection.enumValueOf(nameTagVisibilityClass, "ALWAYS", 0);
+                    collisionRuleAlways = FastReflection.enumValueOf(collisionRuleClass, "ALWAYS", 0);
+                }
+            }
+            ENUM_NAME_TAG_VISIBILITY = nameTagVisibilityAlways.getClass();
+            ENUM_COLLISION_RULE = collisionRuleAlways.getClass();
+            ENUM_NAME_TAG_VISIBILITY_ALWAYS = nameTagVisibilityAlways;
+            ENUM_COLLISION_RULE_ALWAYS = collisionRuleAlways;
 
             for (Class<?> clazz : Arrays.asList(packetSbObjClass, packetSbDisplayObjClass, packetSbScoreClass, packetSbTeamClass, sbTeamClass)) {
                 if (clazz == null) {
@@ -733,8 +752,9 @@ public abstract class FastBoardBase<T> {
             setField(team, CHAT_FORMAT_ENUM, RESET_FORMATTING); // Color
             setComponentField(team, prefix, 1); // Prefix
             setComponentField(team, suffix, 2); // Suffix
-            setField(team, String.class, "always", 0); // Visibility
-            setField(team, String.class, "always", 1); // Collisions
+            setField(team, ENUM_NAME_TAG_VISIBILITY, ENUM_NAME_TAG_VISIBILITY_ALWAYS, 0);
+            int collisionRuleIndex = ENUM_NAME_TAG_VISIBILITY.equals(ENUM_COLLISION_RULE) ? 1 : 0; // Separated enums for 1.21.5+
+            setField(team, ENUM_COLLISION_RULE, ENUM_COLLISION_RULE_ALWAYS, collisionRuleIndex);
             setField(packet, Optional.class, Optional.of(team));
         } else {
             setComponentField(packet, prefix, 2); // Prefix


### PR DESCRIPTION
The serializable team class now uses enums instead of magic strings. Those enums are present since at least Minecraft 1.9.4, but were not used in the packet fields before.

Tested on:
- Paper 1.21.5 (legacy color codes/Mojang mappings) - not yet released
- Spigot 1.21.5 (legacy color codes/Spigot mappings)
- Paper 1.21.4 (legacy color codes/Mojang mappings)
- Spigot 1.21.4 (legacy color codes/Spigot mappings)
- Paper 1.17.1
- Spigot 1.8.8

- Fix #70