### PR TITLE
Fix the scoreboard being blank when running CanvasMC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,13 +52,13 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>5.1.1</version>
+            <version>5.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>5.1.1</version>
+            <version>5.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -83,9 +83,9 @@ public abstract class FastBoardBase<T> {
     private static final Object DUMMY_SCOREBOARD_CRITERIA;
 
     // handles for methods that set the raw component fields of a scoreboard team. canvas only
-    private static final MethodHandle SET_PLAYER_SUFFIX_RAW;
-    private static final MethodHandle SET_PLAYER_PREFIX_RAW;
-    private static final MethodHandle SET_DISPLAY_NAME_RAW;
+    private static MethodHandle SET_PLAYER_SUFFIX_RAW = null;
+    private static MethodHandle SET_PLAYER_PREFIX_RAW = null;
+    private static MethodHandle SET_DISPLAY_NAME_RAW = null;
 
     // method to check if we are on a canvas server
     private static boolean isCanvas() {
@@ -147,29 +147,31 @@ public abstract class FastBoardBase<T> {
             Class<?> objectiveCriteriaClass = FastReflection.nmsClass("world.scores.criteria", "IScoreboardCriteria", "ObjectiveCriteria");
             PLAYER_TEAM = lookup.unreflectConstructor(playerTeamClass.getConstructor(scoreboardClass, String.class));
 
-            // Canvas has changed the way scoreboard teams work, so we need to use reflection to find the methods that set the raw component fields
-            List<Method> teamMethods = Stream.concat(
-                    Arrays.stream(playerTeamClass.getSuperclass().getDeclaredMethods()),
-                    Arrays.stream(playerTeamClass.getDeclaredMethods())
-            ).collect(Collectors.toList());
+            if (isCanvas()) {
+                // Canvas has changed the way scoreboard teams work, so we need to use reflection to find the methods that set the raw component fields
+                List<Method> teamMethods = Stream.concat(
+                        Arrays.stream(playerTeamClass.getSuperclass().getDeclaredMethods()),
+                        Arrays.stream(playerTeamClass.getDeclaredMethods())
+                ).collect(Collectors.toList());
 
-            Method setDisplayNameRaw = teamMethods.stream()
-                    .filter(m -> m.getName().equals("setDisplayNameRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
-                    .findFirst().orElseThrow(NoSuchMethodException::new);
-            setDisplayNameRaw.setAccessible(true);
-            SET_DISPLAY_NAME_RAW = lookup.unreflect(setDisplayNameRaw);
+                Method setDisplayNameRaw = teamMethods.stream()
+                        .filter(m -> m.getName().equals("setDisplayNameRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                        .findFirst().orElseThrow(NoSuchMethodException::new);
+                setDisplayNameRaw.setAccessible(true);
+                SET_DISPLAY_NAME_RAW = lookup.unreflect(setDisplayNameRaw);
 
-            Method setPlayerPrefixRaw = teamMethods.stream()
-                    .filter(m -> m.getName().equals("setPlayerPrefixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
-                    .findFirst().orElseThrow(NoSuchMethodException::new);
-            setPlayerPrefixRaw.setAccessible(true);
-            SET_PLAYER_PREFIX_RAW = lookup.unreflect(setPlayerPrefixRaw);
+                Method setPlayerPrefixRaw = teamMethods.stream()
+                        .filter(m -> m.getName().equals("setPlayerPrefixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                        .findFirst().orElseThrow(NoSuchMethodException::new);
+                setPlayerPrefixRaw.setAccessible(true);
+                SET_PLAYER_PREFIX_RAW = lookup.unreflect(setPlayerPrefixRaw);
 
-            Method setPlayerSuffixRaw = teamMethods.stream()
-                    .filter(m -> m.getName().equals("setPlayerSuffixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
-                    .findFirst().orElseThrow(NoSuchMethodException::new);
-            setPlayerSuffixRaw.setAccessible(true);
-            SET_PLAYER_SUFFIX_RAW = lookup.unreflect(setPlayerSuffixRaw);
+                Method setPlayerSuffixRaw = teamMethods.stream()
+                        .filter(m -> m.getName().equals("setPlayerSuffixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                        .findFirst().orElseThrow(NoSuchMethodException::new);
+                setPlayerSuffixRaw.setAccessible(true);
+                SET_PLAYER_SUFFIX_RAW = lookup.unreflect(setPlayerSuffixRaw);
+            }
 
             Class<?> objectiveRenderTypeClass = FastReflection.nmsOptionalClass("world.scores.criteria", "IScoreboardCriteria$EnumScoreboardHealthDisplay", "ObjectiveCriteria$RenderType").orElse(null);
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -881,22 +881,19 @@ public abstract class FastBoardBase<T> {
 
     private void setComponentField(Object packet, T value, int count) throws Throwable {
         Class<?> packetClass = packet.getClass();
-        String className = packetClass.getSimpleName();
+        String className = packet.getClass().getSimpleName();
 
-        // Canvas has changed the way scoreboard teams work, so we need to use reflection to find the methods that set the raw component fields
-        if (className.equals("PlayerTeam") || className.equals("ScoreboardTeam")) {
-            if (isCanvas()) {
-                Object component = toMinecraftComponent(value);
-                if (count == 1) {
-                    SET_DISPLAY_NAME_RAW.invoke(packet, component);
-                    return;
-                } else if (count == 2) {
-                    SET_PLAYER_PREFIX_RAW.invoke(packet, component);
-                    return;
-                } else if (count == 3) {
-                    SET_PLAYER_SUFFIX_RAW.invoke(packet, component);
-                    return;
-                }
+        if (isCanvas() && (className.equals("PlayerTeam") || className.equals("ScoreboardTeam"))) {
+            Object component = toMinecraftComponent(value);
+            if (count == 1) {
+                SET_DISPLAY_NAME_RAW.invoke(packet, component);
+                return;
+            } else if (count == 2) {
+                SET_PLAYER_PREFIX_RAW.invoke(packet, component);
+                return;
+            } else if (count == 3) {
+                SET_PLAYER_SUFFIX_RAW.invoke(packet, component);
+                return;
             }
         }
 

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -80,6 +81,21 @@ public abstract class FastBoardBase<T> {
     private static final Object ENUM_SB_ACTION_CHANGE;
     private static final Object ENUM_SB_ACTION_REMOVE;
     private static final Object DUMMY_SCOREBOARD_CRITERIA;
+
+    // handles for methods that set the raw component fields of a scoreboard team. canvas only
+    private static final MethodHandle SET_PLAYER_SUFFIX_RAW;
+    private static final MethodHandle SET_PLAYER_PREFIX_RAW;
+    private static final MethodHandle SET_DISPLAY_NAME_RAW;
+
+    // method to check if we are on a canvas server
+    private static boolean isCanvas() {
+        try {
+            Class.forName("io.canvasmc.canvas.util.LockedReference");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 
     static {
         try {
@@ -130,6 +146,30 @@ public abstract class FastBoardBase<T> {
             Class<?> objectiveClass = FastReflection.nmsClass("world.scores", "ScoreboardObjective", "Objective");
             Class<?> objectiveCriteriaClass = FastReflection.nmsClass("world.scores.criteria", "IScoreboardCriteria", "ObjectiveCriteria");
             PLAYER_TEAM = lookup.unreflectConstructor(playerTeamClass.getConstructor(scoreboardClass, String.class));
+
+            // Canvas has changed the way scoreboard teams work, so we need to use reflection to find the methods that set the raw component fields
+            List<Method> teamMethods = Stream.concat(
+                    Arrays.stream(playerTeamClass.getSuperclass().getDeclaredMethods()),
+                    Arrays.stream(playerTeamClass.getDeclaredMethods())
+            ).collect(Collectors.toList());
+
+            Method setDisplayNameRaw = teamMethods.stream()
+                    .filter(m -> m.getName().equals("setDisplayNameRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                    .findFirst().orElseThrow(NoSuchMethodException::new);
+            setDisplayNameRaw.setAccessible(true);
+            SET_DISPLAY_NAME_RAW = lookup.unreflect(setDisplayNameRaw);
+
+            Method setPlayerPrefixRaw = teamMethods.stream()
+                    .filter(m -> m.getName().equals("setPlayerPrefixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                    .findFirst().orElseThrow(NoSuchMethodException::new);
+            setPlayerPrefixRaw.setAccessible(true);
+            SET_PLAYER_PREFIX_RAW = lookup.unreflect(setPlayerPrefixRaw);
+
+            Method setPlayerSuffixRaw = teamMethods.stream()
+                    .filter(m -> m.getName().equals("setPlayerSuffixRaw") && m.getParameterCount() == 1 && m.getParameterTypes()[0] == CHAT_COMPONENT_CLASS)
+                    .findFirst().orElseThrow(NoSuchMethodException::new);
+            setPlayerSuffixRaw.setAccessible(true);
+            SET_PLAYER_SUFFIX_RAW = lookup.unreflect(setPlayerSuffixRaw);
 
             Class<?> objectiveRenderTypeClass = FastReflection.nmsOptionalClass("world.scores.criteria", "IScoreboardCriteria$EnumScoreboardHealthDisplay", "ObjectiveCriteria$RenderType").orElse(null);
 
@@ -840,6 +880,26 @@ public abstract class FastBoardBase<T> {
     }
 
     private void setComponentField(Object packet, T value, int count) throws Throwable {
+        Class<?> packetClass = packet.getClass();
+        String className = packetClass.getSimpleName();
+
+        // Canvas has changed the way scoreboard teams work, so we need to use reflection to find the methods that set the raw component fields
+        if (className.equals("PlayerTeam") || className.equals("ScoreboardTeam")) {
+            if (isCanvas()) {
+                Object component = toMinecraftComponent(value);
+                if (count == 1) {
+                    SET_DISPLAY_NAME_RAW.invoke(packet, component);
+                    return;
+                } else if (count == 2) {
+                    SET_PLAYER_PREFIX_RAW.invoke(packet, component);
+                    return;
+                } else if (count == 3) {
+                    SET_PLAYER_SUFFIX_RAW.invoke(packet, component);
+                    return;
+                }
+            }
+        }
+
         if (!VersionType.V1_13.isHigherOrEqual()) {
             String line = value != null ? serializeLine(value) : "";
             setField(packet, String.class, line, count);
@@ -847,9 +907,13 @@ public abstract class FastBoardBase<T> {
         }
 
         int i = 0;
-        for (Field field : PACKETS.get(packet.getClass())) {
-            if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
-                field.set(packet, toMinecraftComponent(value));
+        Field[] fields = PACKETS.get(packetClass);
+        if (fields != null) {
+            for (Field field : fields) {
+                if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
+                    field.set(packet, toMinecraftComponent(value));
+                    break;
+                }
             }
         }
     }

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -881,7 +881,7 @@ public abstract class FastBoardBase<T> {
 
     private void setComponentField(Object packet, T value, int count) throws Throwable {
         Class<?> packetClass = packet.getClass();
-        String className = packet.getClass().getSimpleName();
+        String className = packetClass.getSimpleName();
 
         if (isCanvas() && (className.equals("PlayerTeam") || className.equals("ScoreboardTeam"))) {
             Object component = toMinecraftComponent(value);

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static fr.mrmicky.fastboard.FastReflection.optionalClass;
+
 /**
  * Lightweight packet-based scoreboard API for Bukkit plugins.
  * It can be safely used asynchronously because everything is handled at the packet level.
@@ -88,13 +90,9 @@ public abstract class FastBoardBase<T> {
     private static MethodHandle SET_DISPLAY_NAME_RAW = null;
 
     // method to check if we are on a canvas server
+    private static final boolean CANVAS_PRESENT = optionalClass("io.canvasmc.canvas.util.LockedReference").isPresent();
     private static boolean isCanvas() {
-        try {
-            Class.forName("io.canvasmc.canvas.util.LockedReference");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
+        return CANVAS_PRESENT;
     }
 
     static {

--- a/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
+++ b/src/main/java/fr/mrmicky/fastboard/FastBoardBase.java
@@ -908,12 +908,10 @@ public abstract class FastBoardBase<T> {
 
         int i = 0;
         Field[] fields = PACKETS.get(packetClass);
-        if (fields != null) {
-            for (Field field : fields) {
-                if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
-                    field.set(packet, toMinecraftComponent(value));
-                    break;
-                }
+        for (Field field : fields) {
+            if ((field.getType() == String.class || field.getType() == CHAT_COMPONENT_CLASS) && count == i++) {
+                field.set(packet, toMinecraftComponent(value));
+                break;
             }
         }
     }


### PR DESCRIPTION
I've been using FastBoard for a while now. I primarily use Folia based servers which also includes Canvas. After updating to FastBoard 2.2.0 I've noticed that my scoreboard now looks like this.

<img width="98" height="253" alt="image" src="https://github.com/user-attachments/assets/368c7b96-837e-4915-9b7f-5a1d06b50aac" />

Canvas rewrites and restores the scoreboard system, which was removed on Folia. Before FastBoard 2.2.0 this did not matter, because FastBoard only accessed methods and fields that are also available with the rewritten scoreboard system, so nothing broke.

This pr adds code to check if we are running on a Canvas server and uses methods introduced by Canvas to set the team display name, prefix and suffix so fastboard has full support for the rewritten scoreboard system.

### References
- First message regarding this issue on the FastBoard Discord: https://discord.com/channels/390919659874156560/415691071792742411/1520363936791265380
- Bug report thread on the CanvasMC Discord server: https://discord.com/channels/1168986665038127205/1520448749347016754